### PR TITLE
Add GUI reply bot with persistent settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+settings.json

--- a/replypro_gui.py
+++ b/replypro_gui.py
@@ -44,6 +44,12 @@ class ReplyWorker(QThread):
         # Keep failsafe enabled so moving the mouse to a corner aborts the run
         pyautogui.FAILSAFE = True
 
+        # Switch focus to the previously active window (expected browser)
+        switch_keys = ("command", "tab") if platform.system() == "Darwin" else ("alt", "tab")
+        pyautogui.hotkey(*switch_keys)
+        self.log.emit("Activated previous window.")
+        time.sleep(0.5)
+
         while self._running and count < self.limit:
             # Like sequence: press J then L then R
             pyautogui.press("j")
@@ -193,4 +199,4 @@ if __name__ == "__main__":
     app = QApplication(sys.argv)
     window = ReplyPRO()
     window.show()
-    app.exec()
+    sys.exit(app.exec())

--- a/replypro_gui.py
+++ b/replypro_gui.py
@@ -37,30 +37,33 @@ class ReplyWorker(QThread):
 
         count = 0
         idx = 0
-        pyautogui.PAUSE = 0.5
-        # Disable failsafe so the mouse in the corner doesn't abort the run
-        pyautogui.FAILSAFE = False
+        # Slow down PyAutoGUI actions so the target app can keep up
+        pyautogui.PAUSE = 1.0
+        pyautogui.FAILSAFE = True
 
         # Switch focus away from this window (expected browser is next)
         pyautogui.hotkey("alt", "tab")
         self.log.emit("Activated previous window.")
-        time.sleep(0.5)
+        # Give the OS time to bring the browser to the foreground
+        time.sleep(1.0)
 
         while self._running and count < self.limit:
             # Like sequence: press J then L then R
             pyautogui.press("j")
-            time.sleep(random.uniform(0.5, 1.0))
+            time.sleep(random.uniform(1.0, 1.5))
             pyautogui.press("l")
-            time.sleep(random.uniform(0.5, 1.0))
+            time.sleep(random.uniform(1.0, 1.5))
             pyautogui.press("r")
-            time.sleep(random.uniform(0.5, 1.0))
+            time.sleep(random.uniform(1.0, 1.5))
 
             text = self.replies[idx]
             idx = (idx + 1) % len(self.replies)
-            pyautogui.typewrite(text, interval=random.uniform(0.05, 0.2))
-            time.sleep(random.uniform(0.3, 0.8))
+            pyautogui.typewrite(text, interval=random.uniform(0.08, 0.25))
+            time.sleep(random.uniform(0.5, 1.0))
             # On Windows the "send" shortcut is usually Ctrl+Enter
             pyautogui.hotkey("ctrl", "enter")
+            # Allow a brief moment for the comment to send
+            time.sleep(0.5)
 
             count += 1
             self.log.emit(f"Replied #{count}: '{text}'")

--- a/replypro_gui.py
+++ b/replypro_gui.py
@@ -39,12 +39,13 @@ class ReplyWorker(QThread):
         count = 0
         idx = 0
         # Slow down PyAutoGUI actions so the target app can keep up
-        pyautogui.PAUSE = 1.0
+        pyautogui.PAUSE = 0.5
         # Keep failsafe active so moving the mouse to a corner aborts the run
         pyautogui.FAILSAFE = True
 
         # Switch focus away from this window (expected browser is next)
-        pyautogui.hotkey("alt", "tab")
+        switch_keys = ("command", "tab") if platform.system() == "Darwin" else ("alt", "tab")
+        pyautogui.hotkey(*switch_keys)
         self.log.emit("Activated previous window.")
         # Give the OS time to bring the browser to the foreground
         time.sleep(1.0)

--- a/replypro_gui.py
+++ b/replypro_gui.py
@@ -1,0 +1,197 @@
+import os
+import json
+import time
+import random
+import pyautogui
+from PyQt5.QtWidgets import (
+    QApplication, QWidget, QVBoxLayout, QPushButton, QTextEdit, QLabel,
+    QSpinBox, QHBoxLayout, QMessageBox
+)
+from PyQt5.QtCore import QTimer, QThread, pyqtSignal
+import faulthandler
+
+# Enable faulthandler to help debug crashes
+faulthandler.enable()
+
+
+class ReplyWorker(QThread):
+    """Background worker that types and posts replies automatically."""
+
+    log = pyqtSignal(str)
+
+    def __init__(self, replies, limit, cadence):
+        super().__init__()
+        self.replies = replies
+        self.limit = limit
+        self.cadence = cadence
+        self._running = True
+
+    def run(self):
+        # initial countdown
+        for i in range(10, 0, -1):
+            if not self._running:
+                self.log.emit("Startup cancelled.")
+                return
+            self.log.emit(f"Starting in {i}...")
+            time.sleep(1)
+
+        count = 0
+        idx = 0
+        pyautogui.PAUSE = 0.5
+        # Disable failsafe so the mouse in the corner doesn't abort the run
+        pyautogui.FAILSAFE = False
+
+        # Switch focus away from this window (expected browser is next)
+        pyautogui.hotkey("alt", "tab")
+        self.log.emit("Activated previous window.")
+        time.sleep(0.5)
+
+        while self._running and count < self.limit:
+            # Like sequence: press J then L then R
+            pyautogui.press("j")
+            time.sleep(random.uniform(0.5, 1.0))
+            pyautogui.press("l")
+            time.sleep(random.uniform(0.5, 1.0))
+            pyautogui.press("r")
+            time.sleep(random.uniform(0.5, 1.0))
+
+            text = self.replies[idx]
+            idx = (idx + 1) % len(self.replies)
+            pyautogui.typewrite(text, interval=random.uniform(0.05, 0.2))
+            time.sleep(random.uniform(0.3, 0.8))
+            # On Windows the "send" shortcut is usually Ctrl+Enter
+            pyautogui.hotkey("ctrl", "enter")
+
+            count += 1
+            self.log.emit(f"Replied #{count}: '{text}'")
+
+            delay = self.cadence + random.randint(1, 4)
+            self.log.emit(f"Waiting {delay}s...")
+            for _ in range(delay):
+                if not self._running:
+                    break
+                time.sleep(1)
+
+        self.log.emit(f"Finished: {count} replies.")
+
+    def stop(self):
+        self._running = False
+
+
+class ReplyPRO(QWidget):
+    """Simple GUI for configuring and launching the reply bot."""
+
+    SETTINGS_FILE = "settings.json"
+
+    def __init__(self):
+        super().__init__()
+        self.worker = None
+        self.initUI()
+        self.load_settings()
+
+    def initUI(self):
+        self.setWindowTitle("ReplyPRO 3.0")
+        layout = QVBoxLayout()
+
+        layout.addWidget(QLabel("Replies (one per line):"))
+        self.reply_input = QTextEdit()
+        layout.addWidget(self.reply_input)
+
+        row = QHBoxLayout()
+        row.addWidget(QLabel("Cadence (s):"))
+        self.cadence = QSpinBox()
+        self.cadence.setRange(1, 60)
+        self.cadence.setValue(5)
+        row.addWidget(self.cadence)
+        row.addWidget(QLabel("Limit:"))
+        self.limit = QSpinBox()
+        self.limit.setRange(1, 500)
+        self.limit.setValue(50)
+        row.addWidget(self.limit)
+        layout.addLayout(row)
+
+        # Start/Stop buttons
+        btns = QHBoxLayout()
+        self.start_btn = QPushButton("Start")
+        self.start_btn.clicked.connect(self.start)
+        btns.addWidget(self.start_btn)
+        self.stop_btn = QPushButton("Stop")
+        self.stop_btn.clicked.connect(self.stop)
+        btns.addWidget(self.stop_btn)
+        layout.addLayout(btns)
+
+        # Save/Load settings
+        settings_btns = QHBoxLayout()
+        save_btn = QPushButton("Save Settings")
+        save_btn.clicked.connect(self.save_settings)
+        settings_btns.addWidget(save_btn)
+        load_btn = QPushButton("Load Settings")
+        load_btn.clicked.connect(self.load_settings)
+        settings_btns.addWidget(load_btn)
+        layout.addLayout(settings_btns)
+
+        self.log_view = QTextEdit()
+        self.log_view.setReadOnly(True)
+        layout.addWidget(QLabel("Log:"))
+        layout.addWidget(self.log_view)
+
+        self.setLayout(layout)
+
+    def log(self, message):
+        timestamp = time.strftime('[%H:%M:%S]')
+        QTimer.singleShot(0, lambda: self.log_view.append(f"{timestamp} {message}"))
+
+    def start(self):
+        replies = [r.strip() for r in self.reply_input.toPlainText().splitlines() if r.strip()]
+        if not replies:
+            QMessageBox.warning(self, "No replies", "Add at least one reply.")
+            return
+        if self.worker and self.worker.isRunning():
+            QMessageBox.information(self, "Running", "Bot already active.")
+            return
+        self.worker = ReplyWorker(replies, self.limit.value(), self.cadence.value())
+        self.worker.log.connect(self.log)
+        self.worker.start()
+        self.log("Bot started. Switch to the target window.")
+        # Minimize the GUI so the browser can stay in focus
+        self.showMinimized()
+
+    def stop(self):
+        if self.worker:
+            self.worker.stop()
+            self.log("Stop requested.")
+
+    # --- Settings handling -------------------------------------------------
+    def save_settings(self):
+        data = {
+            "replies": self.reply_input.toPlainText().splitlines(),
+            "cadence": self.cadence.value(),
+            "limit": self.limit.value(),
+        }
+        try:
+            with open(self.SETTINGS_FILE, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2)
+            self.log("Settings saved.")
+        except OSError as exc:
+            self.log(f"Failed to save settings: {exc}")
+
+    def load_settings(self):
+        if not os.path.exists(self.SETTINGS_FILE):
+            return
+        try:
+            with open(self.SETTINGS_FILE, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError) as exc:
+            self.log(f"Failed to load settings: {exc}")
+            return
+        self.reply_input.setPlainText("\n".join(data.get("replies", [])))
+        self.cadence.setValue(data.get("cadence", 5))
+        self.limit.setValue(data.get("limit", 50))
+        self.log("Settings loaded.")
+
+
+if __name__ == "__main__":
+    app = QApplication([])
+    window = ReplyPRO()
+    window.show()
+    app.exec_()

--- a/replypro_gui.py
+++ b/replypro_gui.py
@@ -15,6 +15,9 @@ import faulthandler
 # Enable faulthandler to help debug crashes
 faulthandler.enable()
 
+# Determine platform once for hotkey selection
+IS_MAC = platform.system() == "Darwin"
+
 
 class ReplyWorker(QThread):
     """Background worker that types and posts replies automatically."""
@@ -45,7 +48,7 @@ class ReplyWorker(QThread):
         pyautogui.FAILSAFE = True
 
         # Switch focus to the previously active window (expected browser)
-        switch_keys = ("command", "tab") if platform.system() == "Darwin" else ("alt", "tab")
+        switch_keys = ("command", "tab") if IS_MAC else ("alt", "tab")
         pyautogui.hotkey(*switch_keys)
         self.log.emit("Activated previous window.")
         time.sleep(0.5)
@@ -64,7 +67,7 @@ class ReplyWorker(QThread):
             pyautogui.typewrite(text, interval=random.uniform(0.05, 0.2))
             time.sleep(random.uniform(0.3, 0.8))
             # Platform-specific "send" shortcut (Ctrl+Enter on Windows, Cmd+Enter on macOS)
-            submit_keys = ("command", "enter") if platform.system() == "Darwin" else ("ctrl", "enter")
+            submit_keys = ("command", "enter") if IS_MAC else ("ctrl", "enter")
             pyautogui.hotkey(*submit_keys)
             # Allow a brief moment for the comment to send
             time.sleep(0.5)

--- a/replypro_gui.py
+++ b/replypro_gui.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import json
 import time
 import random
@@ -40,8 +41,8 @@ class ReplyWorker(QThread):
         idx = 0
         # Slow down PyAutoGUI actions so the target app can keep up
         pyautogui.PAUSE = 0.5
-        # Keep failsafe active so moving the mouse to a corner aborts the run
-        pyautogui.FAILSAFE = True
+        # Disable failsafe so the mouse in a corner doesn't abort the run
+        pyautogui.FAILSAFE = False
 
         # Switch focus away from this window (expected browser is next)
         switch_keys = ("command", "tab") if platform.system() == "Darwin" else ("alt", "tab")
@@ -198,7 +199,7 @@ class ReplyPRO(QWidget):
 
 
 if __name__ == "__main__":
-    app = QApplication([])
+    app = QApplication(sys.argv)
     window = ReplyPRO()
     window.show()
-    app.exec_()
+    app.exec()

--- a/replypro_gui.py
+++ b/replypro_gui.py
@@ -2,6 +2,7 @@ import os
 import json
 import time
 import random
+import platform
 import pyautogui
 from PyQt5.QtWidgets import (
     QApplication, QWidget, QVBoxLayout, QPushButton, QTextEdit, QLabel,
@@ -39,6 +40,7 @@ class ReplyWorker(QThread):
         idx = 0
         # Slow down PyAutoGUI actions so the target app can keep up
         pyautogui.PAUSE = 1.0
+        # Keep failsafe active so moving the mouse to a corner aborts the run
         pyautogui.FAILSAFE = True
 
         # Switch focus away from this window (expected browser is next)
@@ -60,8 +62,9 @@ class ReplyWorker(QThread):
             idx = (idx + 1) % len(self.replies)
             pyautogui.typewrite(text, interval=random.uniform(0.08, 0.25))
             time.sleep(random.uniform(0.5, 1.0))
-            # On Windows the "send" shortcut is usually Ctrl+Enter
-            pyautogui.hotkey("ctrl", "enter")
+            # Platform-specific "send" shortcut (Ctrl+Enter on Windows, Cmd+Enter on macOS)
+            submit_keys = ("command", "enter") if platform.system() == "Darwin" else ("ctrl", "enter")
+            pyautogui.hotkey(*submit_keys)
             # Allow a brief moment for the comment to send
             time.sleep(0.5)
 

--- a/replypro_gui.py
+++ b/replypro_gui.py
@@ -41,29 +41,22 @@ class ReplyWorker(QThread):
         idx = 0
         # Slow down PyAutoGUI actions so the target app can keep up
         pyautogui.PAUSE = 0.5
-        # Disable failsafe so the mouse in a corner doesn't abort the run
-        pyautogui.FAILSAFE = False
-
-        # Switch focus away from this window (expected browser is next)
-        switch_keys = ("command", "tab") if platform.system() == "Darwin" else ("alt", "tab")
-        pyautogui.hotkey(*switch_keys)
-        self.log.emit("Activated previous window.")
-        # Give the OS time to bring the browser to the foreground
-        time.sleep(1.0)
+        # Keep failsafe enabled so moving the mouse to a corner aborts the run
+        pyautogui.FAILSAFE = True
 
         while self._running and count < self.limit:
             # Like sequence: press J then L then R
             pyautogui.press("j")
-            time.sleep(random.uniform(1.0, 1.5))
+            time.sleep(random.uniform(0.5, 1.0))
             pyautogui.press("l")
-            time.sleep(random.uniform(1.0, 1.5))
+            time.sleep(random.uniform(0.5, 1.0))
             pyautogui.press("r")
-            time.sleep(random.uniform(1.0, 1.5))
+            time.sleep(random.uniform(0.5, 1.0))
 
             text = self.replies[idx]
             idx = (idx + 1) % len(self.replies)
-            pyautogui.typewrite(text, interval=random.uniform(0.08, 0.25))
-            time.sleep(random.uniform(0.5, 1.0))
+            pyautogui.typewrite(text, interval=random.uniform(0.05, 0.2))
+            time.sleep(random.uniform(0.3, 0.8))
             # Platform-specific "send" shortcut (Ctrl+Enter on Windows, Cmd+Enter on macOS)
             submit_keys = ("command", "enter") if platform.system() == "Darwin" else ("ctrl", "enter")
             pyautogui.hotkey(*submit_keys)
@@ -160,9 +153,7 @@ class ReplyPRO(QWidget):
         self.worker = ReplyWorker(replies, self.limit.value(), self.cadence.value())
         self.worker.log.connect(self.log)
         self.worker.start()
-        self.log("Bot started. Switch to the target window.")
-        # Minimize the GUI so the browser can stay in focus
-        self.showMinimized()
+        self.log("Bot started. Ensure the browser is focused.")
 
     def stop(self):
         if self.worker:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PyQt5
+pyautogui


### PR DESCRIPTION
## Summary
- implement ReplyPRO GUI using PyQt5 that types replies, likes posts and submits with Ctrl+Enter on Windows
- add load/save of replies, cadence and limit via JSON settings file
- provide requirements and ignore generated settings
- ensure bot automatically switches focus to previous window before typing

## Testing
- `python -m py_compile replypro_gui.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6e2a32fe08321a9cdd9cda551f54d