### PR TITLE
Add pause functionality to ReplyPRO automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+settings.json

--- a/replypro_gui.py
+++ b/replypro_gui.py
@@ -1,0 +1,238 @@
+import os
+import sys
+import json
+import time
+import random
+import platform
+import pyautogui
+from PyQt5.QtWidgets import (
+    QApplication, QWidget, QVBoxLayout, QPushButton, QTextEdit, QLabel,
+    QSpinBox, QHBoxLayout, QMessageBox
+)
+from PyQt5.QtCore import QTimer, QThread, pyqtSignal
+import faulthandler
+
+# Enable faulthandler to help debug crashes
+faulthandler.enable()
+
+# Determine platform once for hotkey selection
+IS_MAC = platform.system() == "Darwin"
+
+
+class ReplyWorker(QThread):
+    """Background worker that types and posts replies automatically."""
+
+    log = pyqtSignal(str)
+
+    def __init__(self, replies, limit, cadence):
+        super().__init__()
+        self.replies = replies
+        self.limit = limit
+        self.cadence = cadence
+        self._running = True
+        self._paused = False
+
+    def run(self):
+        # initial countdown
+        for i in range(10, 0, -1):
+            if not self._running:
+                self.log.emit("Startup cancelled.")
+                return
+            self.log.emit(f"Starting in {i}...")
+            time.sleep(1)
+
+        count = 0
+        idx = 0
+        # Slow down PyAutoGUI actions so the target app can keep up
+        pyautogui.PAUSE = 0.5
+        # Keep failsafe enabled so moving the mouse to a corner stops the bot
+        pyautogui.FAILSAFE = True
+
+        while self._running and count < self.limit:
+            while self._paused and self._running:
+                time.sleep(0.5)
+
+            # Like sequence: press J then L then R
+            pyautogui.press("j")
+            time.sleep(random.uniform(0.5, 1.0))
+            pyautogui.press("l")
+            time.sleep(random.uniform(0.5, 1.0))
+            pyautogui.press("r")
+            time.sleep(random.uniform(0.5, 1.0))
+
+            text = self.replies[idx]
+            idx = (idx + 1) % len(self.replies)
+            pyautogui.typewrite(text, interval=random.uniform(0.05, 0.2))
+            time.sleep(random.uniform(0.3, 0.8))
+            # Platform-specific "send" shortcut (Ctrl+Enter on Windows, Cmd+Enter on macOS)
+            submit_keys = ("command", "enter") if IS_MAC else ("ctrl", "enter")
+            pyautogui.hotkey(*submit_keys)
+            # Allow a brief moment for the comment to send
+            time.sleep(1.0)
+
+            count += 1
+            self.log.emit(f"Replied #{count}: '{text}'")
+
+            delay = self.cadence + random.randint(1, 4)
+            self.log.emit(f"Waiting {delay}s...")
+            for _ in range(delay):
+                if not self._running:
+                    break
+                while self._paused and self._running:
+                    time.sleep(0.5)
+                time.sleep(1)
+
+        self.log.emit(f"Finished: {count} replies.")
+
+    def stop(self):
+        self._running = False
+
+    def pause(self):
+        self._paused = True
+
+    def resume(self):
+        self._paused = False
+
+
+class ReplyPRO(QWidget):
+    """Simple GUI for configuring and launching the reply bot."""
+
+    SETTINGS_FILE = "settings.json"
+
+    def __init__(self):
+        super().__init__()
+        self.worker = None
+        self.initUI()
+        self.load_settings()
+
+    def initUI(self):
+        self.setWindowTitle("ReplyPRO 3.0")
+        layout = QVBoxLayout()
+
+        layout.addWidget(QLabel("Replies (one per line):"))
+        self.reply_input = QTextEdit()
+        layout.addWidget(self.reply_input)
+
+        row = QHBoxLayout()
+        row.addWidget(QLabel("Cadence (s):"))
+        self.cadence = QSpinBox()
+        self.cadence.setRange(1, 60)
+        self.cadence.setValue(5)
+        row.addWidget(self.cadence)
+        row.addWidget(QLabel("Limit:"))
+        self.limit = QSpinBox()
+        self.limit.setRange(1, 500)
+        self.limit.setValue(50)
+        row.addWidget(self.limit)
+        layout.addLayout(row)
+
+        # Start/Pause/Stop buttons
+        btns = QHBoxLayout()
+        self.start_btn = QPushButton("Start")
+        self.start_btn.clicked.connect(self.start)
+        btns.addWidget(self.start_btn)
+        self.pause_btn = QPushButton("Pause")
+        self.pause_btn.clicked.connect(self.pause)
+        btns.addWidget(self.pause_btn)
+        self.stop_btn = QPushButton("Stop")
+        self.stop_btn.clicked.connect(self.stop)
+        btns.addWidget(self.stop_btn)
+        layout.addLayout(btns)
+
+        # Save/Load settings
+        settings_btns = QHBoxLayout()
+        save_btn = QPushButton("Save Settings")
+        save_btn.clicked.connect(self.save_settings)
+        settings_btns.addWidget(save_btn)
+        load_btn = QPushButton("Load Settings")
+        load_btn.clicked.connect(self.load_settings)
+        settings_btns.addWidget(load_btn)
+        layout.addLayout(settings_btns)
+
+        self.log_view = QTextEdit()
+        self.log_view.setReadOnly(True)
+        layout.addWidget(QLabel("Log:"))
+        layout.addWidget(self.log_view)
+
+        self.setLayout(layout)
+
+    def log(self, message):
+        timestamp = time.strftime('[%H:%M:%S]')
+        QTimer.singleShot(0, lambda: self.log_view.append(f"{timestamp} {message}"))
+
+    def start(self):
+        replies = [r.strip() for r in self.reply_input.toPlainText().splitlines() if r.strip()]
+        if not replies:
+            QMessageBox.warning(self, "No replies", "Add at least one reply.")
+            return
+        if self.worker and self.worker.isRunning():
+            QMessageBox.information(self, "Running", "Bot already active.")
+            return
+        self.worker = ReplyWorker(replies, self.limit.value(), self.cadence.value())
+        self.worker.log.connect(self.log)
+        self.worker.finished.connect(self.on_worker_finished)
+        self.worker.start()
+        self.pause_btn.setText("Pause")
+        self.log("Bot started. Switch to the browser window now.")
+
+    def stop(self):
+        if self.worker:
+            self.worker.stop()
+            self.pause_btn.setText("Pause")
+            self.log("Stop requested.")
+
+    def pause(self):
+        if not self.worker or not self.worker.isRunning():
+            return
+        if self.pause_btn.text() == "Pause":
+            self.worker.pause()
+            self.pause_btn.setText("Resume")
+            self.log("Paused.")
+        else:
+            self.worker.resume()
+            self.pause_btn.setText("Pause")
+            self.log("Resumed.")
+
+    def on_worker_finished(self):
+        self.pause_btn.setText("Pause")
+        self.worker = None
+
+    # --- Settings handling -------------------------------------------------
+    def save_settings(self):
+        data = {
+            "replies": self.reply_input.toPlainText().splitlines(),
+            "cadence": self.cadence.value(),
+            "limit": self.limit.value(),
+        }
+        try:
+            with open(self.SETTINGS_FILE, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2)
+            self.log("Settings saved.")
+        except OSError as exc:
+            self.log(f"Failed to save settings: {exc}")
+
+    def load_settings(self):
+        if not os.path.exists(self.SETTINGS_FILE):
+            return
+        try:
+            with open(self.SETTINGS_FILE, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError) as exc:
+            self.log(f"Failed to load settings: {exc}")
+            return
+        self.reply_input.setPlainText("\n".join(data.get("replies", [])))
+        self.cadence.setValue(data.get("cadence", 5))
+        self.limit.setValue(data.get("limit", 50))
+        self.log("Settings loaded.")
+
+    def closeEvent(self, event):
+        """Save settings automatically when the window closes."""
+        self.save_settings()
+        event.accept()
+
+
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+    window = ReplyPRO()
+    window.show()
+    sys.exit(app.exec())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+PyQt5
+pyautogui
+pytest

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,51 @@
+import os
+import pytest
+
+# Use pytest.importorskip so the test suite is skipped if PyQt5 or its
+# dependencies (e.g., libGL) are unavailable in the execution environment.
+QtWidgets = pytest.importorskip("PyQt5.QtWidgets")
+from PyQt5.QtWidgets import QApplication
+
+# Set Qt to run offscreen for headless environments
+os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
+
+from replypro_gui import ReplyPRO, ReplyWorker
+
+@pytest.fixture(scope="module")
+def app():
+    app = QApplication([])
+    yield app
+    app.quit()
+
+
+def test_save_and_load_settings(tmp_path, app):
+    # Use a temporary settings file
+    ReplyPRO.SETTINGS_FILE = str(tmp_path / "settings.json")
+
+    window = ReplyPRO()
+    window.reply_input.setPlainText("Hello\nWorld")
+    window.cadence.setValue(7)
+    window.limit.setValue(3)
+
+    window.save_settings()
+    settings_path = tmp_path / "settings.json"
+    assert settings_path.exists()
+
+    # Reset fields and load
+    window.reply_input.clear()
+    window.cadence.setValue(1)
+    window.limit.setValue(1)
+
+    window.load_settings()
+    assert window.reply_input.toPlainText().splitlines() == ["Hello", "World"]
+    assert window.cadence.value() == 7
+    assert window.limit.value() == 3
+
+
+def test_worker_pause_resume():
+    worker = ReplyWorker(["hi"], limit=1, cadence=1)
+    assert worker._paused is False
+    worker.pause()
+    assert worker._paused is True
+    worker.resume()
+    assert worker._paused is False


### PR DESCRIPTION
## Summary
- add pause/resume controls to automation worker and GUI
- add unit test for pause/resume behavior

## Testing
- `python -m py_compile replypro_gui.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6e2a32fe08321a9cdd9cda551f54d