### PR TITLE
Validate screen state after each reply

### DIFF
--- a/replypro_gui.py
+++ b/replypro_gui.py
@@ -93,14 +93,35 @@ class ReplyWorker(QThread):
                 # Platform-specific "send" shortcut (Ctrl+Enter on Windows, Cmd+Enter on macOS)
                 submit_keys = ("command", "enter") if IS_MAC else ("ctrl", "enter")
                 pyautogui.hotkey(*submit_keys)
-                # Allow a brief moment for the comment to send
-                time.sleep(2.0)
+                self.log.emit("Waiting 10s for comment to post...")
+                # Allow ample time for the comment to post before verifying
+                time.sleep(10.0)
+
+                # Verify that the page reflects the expected state after sending
+                try:
+                    posted = pyautogui.locateOnScreen("comment_posted.png", confidence=0.8)
+                    error = pyautogui.locateOnScreen("error_popup.png", confidence=0.8)
+                except Exception as exc:
+                    posted = None
+                    error = None
+                    self.log.emit(f"Screen check failed: {exc}")
+
+                if not posted or error:
+                    self.log.emit("Screen state mismatch detected. Stopping worker.")
+                    screenshot = f"mismatch_{int(time.time())}.png"
+                    try:
+                        pyautogui.screenshot(screenshot)
+                        self.log.emit(f"Saved screenshot to {screenshot}")
+                    except Exception as exc:
+                        self.log.emit(f"Failed to save screenshot: {exc}")
+                    self._running = False
+                    break
 
                 count += 1
                 self.log.emit(f"Replied #{count}: '{text}'")
 
-                delay = self.cadence + random.randint(1, 4)
-                self.log.emit(f"Waiting {delay}s...")
+                delay = max(10, self.cadence + random.randint(1, 4))
+                self.log.emit(f"Waiting {delay}s before next reply...")
                 for _ in range(delay):
                     if not self._running:
                         break


### PR DESCRIPTION
## Summary
- Wait 10s after submitting a comment before verifying the screen
- Enforce a minimum 10s delay between replies

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7fe0e44308321a5ce38618fb6aebb