### PR TITLE
Add pause and resume functionality

### DIFF
--- a/replypro_gui.py
+++ b/replypro_gui.py
@@ -41,6 +41,7 @@ class ReplyWorker(QThread):
         self.limit = limit
         self.cadence = cadence
         self._running = True
+        self._paused = False
 
     def run(self):
         try:
@@ -67,6 +68,8 @@ class ReplyWorker(QThread):
             time.sleep(2.0)
 
             while self._running and count < self.limit:
+                while self._paused and self._running:
+                    time.sleep(0.1)
                 if not check_network():
                     self.log.emit("Network check failed. Stopping worker.")
                     self._running = False
@@ -124,6 +127,8 @@ class ReplyWorker(QThread):
                 for _ in range(delay):
                     if not self._running:
                         break
+                    while self._paused and self._running:
+                        time.sleep(0.1)
                     time.sleep(1)
 
             self.log.emit(f"Finished: {count} replies.")
@@ -132,6 +137,15 @@ class ReplyWorker(QThread):
 
     def stop(self):
         self._running = False
+
+    def pause(self):
+        self._paused = True
+
+    def resume(self):
+        self._paused = False
+
+    def is_paused(self):
+        return self._paused
 
 
 class ReplyPRO(QWidget):
@@ -166,13 +180,20 @@ class ReplyPRO(QWidget):
         row.addWidget(self.limit)
         layout.addLayout(row)
 
-        # Start/Stop buttons
+        # Start/Pause/Stop buttons
         btns = QHBoxLayout()
         self.start_btn = QPushButton("Start")
         self.start_btn.clicked.connect(self.start)
+        self.start_btn.setObjectName("start_btn")
         btns.addWidget(self.start_btn)
+        self.pause_btn = QPushButton("Pause")
+        self.pause_btn.clicked.connect(self.pause_or_resume)
+        self.pause_btn.setEnabled(False)
+        self.pause_btn.setObjectName("pause_btn")
+        btns.addWidget(self.pause_btn)
         self.stop_btn = QPushButton("Stop")
         self.stop_btn.clicked.connect(self.stop)
+        self.stop_btn.setObjectName("stop_btn")
         btns.addWidget(self.stop_btn)
         layout.addLayout(btns)
 
@@ -209,6 +230,9 @@ class ReplyPRO(QWidget):
         self.worker.log.connect(self.log)
         self.worker.start()
 
+        self.pause_btn.setEnabled(True)
+        self.pause_btn.setText("Pause")
+
 
         self.log("Bot started. Switch to the browser window now.")
         # Minimize the GUI so the browser receives keystrokes
@@ -218,6 +242,20 @@ class ReplyPRO(QWidget):
         if self.worker:
             self.worker.stop()
             self.log("Stop requested.")
+        self.pause_btn.setEnabled(False)
+        self.pause_btn.setText("Pause")
+
+    def pause_or_resume(self):
+        if not self.worker:
+            return
+        if not self.worker.is_paused():
+            self.worker.pause()
+            self.pause_btn.setText("Resume")
+            self.log("Pause requested.")
+        else:
+            self.worker.resume()
+            self.pause_btn.setText("Pause")
+            self.log("Resume requested.")
 
     # --- Settings handling -------------------------------------------------
     def save_settings(self):

--- a/tests/test_pause.py
+++ b/tests/test_pause.py
@@ -1,0 +1,37 @@
+import os
+import pytest
+
+QtWidgets = pytest.importorskip("PyQt5.QtWidgets")
+from PyQt5.QtWidgets import QApplication
+
+os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
+
+from replypro_gui import ReplyPRO, ReplyWorker
+
+
+@pytest.fixture(scope="module")
+def app():
+    app = QApplication([])
+    yield app
+    app.quit()
+
+
+def test_pause_button_exists_and_toggles(tmp_path, app):
+    ReplyPRO.SETTINGS_FILE = str(tmp_path / "settings.json")
+    window = ReplyPRO()
+
+    pause_button = window.findChild(QtWidgets.QPushButton, "pause_btn")
+    assert pause_button is not None
+    assert pause_button is window.pause_btn
+    assert not pause_button.isEnabled()
+
+    window.worker = ReplyWorker(["hi"], 1, 1)
+
+    # Enable manually for test and toggle
+    pause_button.setEnabled(True)
+    window.pause_or_resume()
+    assert window.worker.is_paused()
+    assert pause_button.text() == "Resume"
+    window.pause_or_resume()
+    assert not window.worker.is_paused()
+    assert pause_button.text() == "Pause"


### PR DESCRIPTION
## Summary
- allow ReplyWorker to pause and resume while running
- add Pause button to GUI with toggle behavior and expose it via object name
- cover pause button existence and toggle behavior with new test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7feecf7ec8321959ea80ac78084c5