### PR TITLE
Add randomized keyboard interactions and clean up

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,3 @@ PyQt5
 pyautogui
 pytest
 
-main
-

--- a/tests/test_pause.py
+++ b/tests/test_pause.py
@@ -36,4 +36,3 @@ def test_pause_button_exists_and_toggles(tmp_path, app):
     window.pause_or_resume()
     assert not window.worker.is_paused()
     assert pause_button.text() == "Pause"
-main


### PR DESCRIPTION
## Summary
- simplify ReplyWorker to send replies via J/L/R key sequence with random pauses
- remove unused network/screen checks and stray text artifacts
- tidy test and requirements files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b807233b8c8321a4a811c94532d559