### PR TITLE
Improve reply bot timing and actions

### DIFF
--- a/replypro_gui.py
+++ b/replypro_gui.py
@@ -47,17 +47,16 @@ class ReplyWorker(QThread):
             idx = 0
 
             # Configure PyAutoGUI for smoother, safer interactions
-
-            # Use a longer pause to slow down consecutive actions so pages can load
+            # Use a longer pause between actions so pages have time to load
             pyautogui.PAUSE = 1.0
-main
             pyautogui.FAILSAFE = True
 
             # Switch focus to the previously active window (expected browser)
             switch_keys = ("command", "tab") if IS_MAC else ("alt", "tab")
             pyautogui.hotkey(*switch_keys)
             self.log.emit("Activated previous window.")
-            time.sleep(2.0)
+            # Give the browser a moment to become active
+            time.sleep(3.0)
 
             while self._running and count < self.limit:
                 while self._paused and self._running:
@@ -73,28 +72,22 @@ main
 
                 # Like the current post
                 pyautogui.press("l")
-                time.sleep(random.uniform(2.0, 3.0))
+                time.sleep(random.uniform(2.0, 4.0))
 
                 # Open the reply field
                 pyautogui.press("r")
-                time.sleep(random.uniform(2.0, 3.0))
-main
+                time.sleep(random.uniform(3.0, 5.0))
 
                 text = self.replies[idx]
                 idx = (idx + 1) % len(self.replies)
                 pyautogui.typewrite(text, interval=random.uniform(0.05, 0.2))
 
-                time.sleep(random.uniform(0.5, 1.0))
+                # brief pause before submitting the reply
+                time.sleep(random.uniform(0.5, 1.5))
 
-
-                # Platform-specific "send" shortcut (Ctrl+Enter on Windows, Cmd+Enter on macOS)
-                submit_keys = ("command", "enter") if IS_MAC else ("ctrl", "enter")
-                pyautogui.hotkey(*submit_keys)
-
-                # allow the comment to post fully
-                time.sleep(random.uniform(3.0, 5.0))
-
-main
+                # Hit Enter to submit the reply and allow time for it to post
+                pyautogui.press("enter")
+                time.sleep(random.uniform(4.0, 6.0))
                 count += 1
                 self.log.emit(f"Replied #{count}: '{text}'")
 


### PR DESCRIPTION
## Summary
- Slow actions so pages can load before interacting
- Press J, L, R, type reply, and hit Enter with explicit pauses
- Switch to browser and let it activate before starting

## Testing
- `pytest -q` *(skipped: PyQt5 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b817c113e08321b06332a7458d6aea