### PR TITLE
Ensure reply box closes before next post

### DIFF
--- a/replypro_gui.py
+++ b/replypro_gui.py
@@ -88,6 +88,11 @@ class ReplyWorker(QThread):
                 # Hit Enter to submit the reply and allow time for it to post
                 pyautogui.press("enter")
                 time.sleep(random.uniform(4.0, 6.0))
+
+                # Close the reply box so navigation shortcuts work on the next loop
+                pyautogui.press("esc")
+                time.sleep(random.uniform(1.0, 2.0))
+
                 count += 1
                 self.log.emit(f"Replied #{count}: '{text}'")
 


### PR DESCRIPTION
## Summary
- Close the reply box with `Esc` after submitting a reply so navigation shortcuts work

## Testing
- `pytest -q` (skipped: PyQt dependencies not available)


------
https://chatgpt.com/codex/tasks/task_e_68b8216f9edc8321b281b66746aee790