### PR TITLE
Switch to pynput-based keyboard controller

### DIFF
--- a/keyboard_controller.py
+++ b/keyboard_controller.py
@@ -1,0 +1,40 @@
+import time
+from pynput.keyboard import Controller, Key
+
+# Mapping of string names to pynput Key constants
+_KEY_MAP = {
+    "enter": Key.enter,
+    "esc": Key.esc,
+    "tab": Key.tab,
+    "alt": Key.alt,
+    "command": Key.cmd,
+    "cmd": Key.cmd,
+}
+
+
+class KeyboardController:
+    """Wrapper around pynput's Controller providing simple key helpers."""
+
+    def __init__(self):
+        self._controller = Controller()
+
+    def _to_key(self, key: str):
+        return _KEY_MAP.get(key, key)
+
+    def press(self, key: str) -> None:
+        k = self._to_key(key)
+        self._controller.press(k)
+        self._controller.release(k)
+
+    def hotkey(self, *keys: str) -> None:
+        mapped = [self._to_key(k) for k in keys]
+        for k in mapped:
+            self._controller.press(k)
+        for k in reversed(mapped):
+            self._controller.release(k)
+
+    def typewrite(self, text: str, interval: float = 0.0) -> None:
+        for ch in text:
+            self.press(ch)
+            if interval:
+                time.sleep(interval)

--- a/replypro_gui.py
+++ b/replypro_gui.py
@@ -4,7 +4,7 @@ import json
 import time
 import random
 import platform
-import pyautogui
+from keyboard_controller import KeyboardController
 from PyQt5.QtWidgets import (
     QApplication, QWidget, QVBoxLayout, QPushButton, QTextEdit, QLabel,
     QSpinBox, QHBoxLayout, QMessageBox
@@ -32,6 +32,7 @@ class ReplyWorker(QThread):
         self.cadence = cadence
         self._running = True
         self._paused = False
+        self.keyboard = KeyboardController()
 
     def run(self):
         try:
@@ -46,14 +47,9 @@ class ReplyWorker(QThread):
             count = 0
             idx = 0
 
-            # Configure PyAutoGUI for smoother, safer interactions
-            # Use a longer pause between actions so pages have time to load
-            pyautogui.PAUSE = 1.0
-            pyautogui.FAILSAFE = True
-
             # Switch focus to the previously active window (expected browser)
             switch_keys = ("command", "tab") if IS_MAC else ("alt", "tab")
-            pyautogui.hotkey(*switch_keys)
+            self.keyboard.hotkey(*switch_keys)
             self.log.emit("Activated previous window.")
             # Give the browser a moment to become active
             time.sleep(3.0)
@@ -66,31 +62,31 @@ class ReplyWorker(QThread):
                 # Move forward through a few posts with 'J'
                 jumps = random.randint(1, 3)
                 for _ in range(jumps):
-                    pyautogui.press("j")
+                    self.keyboard.press("j")
                     # give the platform time to load the next post
                     time.sleep(random.uniform(3.0, 5.0))
 
                 # Like the current post
-                pyautogui.press("l")
+                self.keyboard.press("l")
                 time.sleep(random.uniform(2.0, 4.0))
 
                 # Open the reply field
-                pyautogui.press("r")
+                self.keyboard.press("r")
                 time.sleep(random.uniform(3.0, 5.0))
 
                 text = self.replies[idx]
                 idx = (idx + 1) % len(self.replies)
-                pyautogui.typewrite(text, interval=random.uniform(0.05, 0.2))
+                self.keyboard.typewrite(text, interval=random.uniform(0.05, 0.2))
 
                 # brief pause before submitting the reply
                 time.sleep(random.uniform(0.5, 1.5))
 
                 # Hit Enter to submit the reply and allow time for it to post
-                pyautogui.press("enter")
+                self.keyboard.press("enter")
                 time.sleep(random.uniform(4.0, 6.0))
 
                 # Close the reply box so navigation shortcuts work on the next loop
-                pyautogui.press("esc")
+                self.keyboard.press("esc")
                 time.sleep(random.uniform(1.0, 2.0))
 
                 count += 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyQt5
-pyautogui
+pynput
 pytest
 

--- a/tests/test_keyboard_controller.py
+++ b/tests/test_keyboard_controller.py
@@ -1,0 +1,39 @@
+import pynput.keyboard as pk
+from keyboard_controller import KeyboardController
+
+
+class DummyController:
+    def __init__(self):
+        self.events = []
+
+    def press(self, key):
+        self.events.append(("press", key))
+
+    def release(self, key):
+        self.events.append(("release", key))
+
+
+def test_hotkey(monkeypatch):
+    kc = KeyboardController()
+    dummy = DummyController()
+    monkeypatch.setattr(kc, "_controller", dummy)
+    kc.hotkey("alt", "tab")
+    assert dummy.events == [
+        ("press", pk.Key.alt),
+        ("press", pk.Key.tab),
+        ("release", pk.Key.tab),
+        ("release", pk.Key.alt),
+    ]
+
+
+def test_typewrite(monkeypatch):
+    kc = KeyboardController()
+    dummy = DummyController()
+    monkeypatch.setattr(kc, "_controller", dummy)
+    kc.typewrite("ab")
+    assert dummy.events == [
+        ("press", "a"),
+        ("release", "a"),
+        ("press", "b"),
+        ("release", "b"),
+    ]


### PR DESCRIPTION
## Summary
- Replace pyautogui calls in `ReplyWorker` with a new `KeyboardController` built on `pynput`
- Add `pynput` dependency and tests for combo and text typing

## Testing
- `pip install pynput` *(fails: Could not find a version that satisfies the requirement pynput)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pynput')*

------
https://chatgpt.com/codex/tasks/task_e_68b84920d0788321ac6ff0feb175ab62