### PR TITLE
Rename entry script to x

### DIFF
--- a/x.py
+++ b/x.py
@@ -2,7 +2,7 @@
 
 This thin wrapper simply launches the :class:`ReplyPRO` GUI from
 ``replypro_gui``.  It exists so the application can be started with
-``python replybot.py`` and to match the expected program name in user
+``python x.py`` and to match the expected program name in user
 instructions.
 """
 


### PR DESCRIPTION
## Summary
- Rename main entry script from `replybot.py` to `x.py` and update startup instructions accordingly

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: ImportError about X connection)*


------
https://chatgpt.com/codex/tasks/task_e_68c2872ac13483219f5771445b114ee3