### PR TITLE
feat: add scheduler launch option to main entry

### DIFF
--- a/x.py
+++ b/x.py
@@ -1,18 +1,46 @@
 """Entry point for the Reply Bot application.
 
-This thin wrapper simply launches the :class:`ReplyPRO` GUI from
-``replypro_gui``.  It exists so the application can be started with
-``python x.py`` and to match the expected program name in user
-instructions.
+This wrapper can launch either the :class:`ReplyPRO` GUI or the manual
+"X Scheduler" interface.  By default ``python x.py`` starts the ReplyPRO
+PyQt5 application.  Passing ``--scheduler`` will instead launch the
+Tkinter‑based scheduler.
 """
 
+import argparse
 import sys
-from PyQt5.QtWidgets import QApplication
-from replypro_gui import ReplyPRO
 
 
-if __name__ == "__main__":
+def run_replypro() -> None:
+    """Launch the original ReplyPRO PyQt5 GUI."""
+
+    from PyQt5.QtWidgets import QApplication
+    from replypro_gui import ReplyPRO
+
     app = QApplication(sys.argv)
     window = ReplyPRO()
     window.show()
     sys.exit(app.exec())
+
+
+def run_scheduler() -> None:
+    """Launch the X Scheduler Tkinter GUI."""
+
+    from x_scheduler_gui_safe import App
+
+    app = App()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Reply Bot launcher")
+    parser.add_argument(
+        "--scheduler",
+        action="store_true",
+        help="Launch the X Scheduler interface instead of ReplyPRO",
+    )
+    args = parser.parse_args()
+
+    if args.scheduler:
+        run_scheduler()
+    else:
+        run_replypro()


### PR DESCRIPTION
## Summary
- allow `x.py` to launch either ReplyPRO or the Tkinter scheduler via `--scheduler`

## Testing
- `pytest tests/test_settings.py -q` *(skipped: PyQt5 missing libGL)*
- `pytest tests/test_pause.py -q` *(skipped: PyQt5 missing libGL)*
- `pytest tests/test_keyboard_controller.py -q` *(error: failed to acquire X connection)*

------
https://chatgpt.com/codex/tasks/task_e_68c28cba72e08321873f7608c35115b1