### PR TITLE
Remove stray main lines from x.py

### DIFF
--- a/x.py
+++ b/x.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-main
 r"""
 X Scheduler (Manual/Compliant Edition)
 --------------------------------------
@@ -876,4 +875,3 @@ class App(tk.Tk):
 if __name__ == "__main__":
     app = App()
     app.mainloop()
-main


### PR DESCRIPTION
## Summary
- Remove extraneous `main` statements that broke `from __future__` placement and caused `SyntaxError`
- Ensure x.py ends cleanly at the GUI entrypoint

## Testing
- `python -m py_compile x.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2b31422e483219c94dd0235cac588