### PR TITLE
Add connection verification and adaptive page wait

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ PyQt5
 pynput
 pytest
 pyperclip
+requests
 


### PR DESCRIPTION
## Summary
- add `ensure_connection` helper to validate network access before opening a search page
- wait adaptively for page load using connection time with configurable BASE_WAIT and MAX_WAIT
- include requests dependency

## Testing
- `pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68c2c54ce8888321849844bf164aeadf