### PR TITLE
Handle optional requests dependency and silence import warnings

### DIFF
--- a/tests/test_keyboard_controller.py
+++ b/tests/test_keyboard_controller.py
@@ -1,5 +1,7 @@
 import pytest
-pk = pytest.importorskip("pynput.keyboard")
+pk = pytest.importorskip(
+    "pynput.keyboard", reason="requires pynput", exc_type=ImportError
+)
 from keyboard_controller import KeyboardController, is_app_generated
 
 

--- a/tests/test_pause.py
+++ b/tests/test_pause.py
@@ -1,12 +1,16 @@
 import os
 import pytest
 
-QtWidgets = pytest.importorskip("PyQt5.QtWidgets")
+QtWidgets = pytest.importorskip(
+    "PyQt5.QtWidgets", reason="requires PyQt5", exc_type=ImportError
+)
 from PyQt5.QtWidgets import QApplication
 
 os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
 
-replypro_gui = pytest.importorskip("replypro_gui")
+replypro_gui = pytest.importorskip(
+    "replypro_gui", reason="requires replypro_gui", exc_type=ImportError
+)
 ReplyPRO = replypro_gui.ReplyPRO
 ReplyWorker = replypro_gui.ReplyWorker
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3,13 +3,17 @@ import pytest
 
 # Use pytest.importorskip so the test suite is skipped if PyQt5 or its
 # dependencies (e.g., libGL) are unavailable in the execution environment.
-QtWidgets = pytest.importorskip("PyQt5.QtWidgets")
+QtWidgets = pytest.importorskip(
+    "PyQt5.QtWidgets", reason="requires PyQt5", exc_type=ImportError
+)
 from PyQt5.QtWidgets import QApplication
 
 # Set Qt to run offscreen for headless environments
 os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
 
-replypro_gui = pytest.importorskip("replypro_gui")
+replypro_gui = pytest.importorskip(
+    "replypro_gui", reason="requires replypro_gui", exc_type=ImportError
+)
 ReplyPRO = replypro_gui.ReplyPRO
 
 @pytest.fixture(scope="module")

--- a/x.py
+++ b/x.py
@@ -40,7 +40,11 @@ from tkinter import ttk, messagebox, scrolledtext, filedialog, simpledialog
 from urllib.parse import quote as url_quote
 from pynput import keyboard as pynkeyboard
 from keyboard_controller import KeyboardController, is_app_generated
-import requests
+
+try:
+    import requests
+except Exception:  # pragma: no cover - optional dependency
+    requests = None
 
 try:
     import pyperclip
@@ -75,6 +79,8 @@ BASE_WAIT = 3
 MAX_WAIT = 15
 
 def ensure_connection(url: str, timeout: float) -> float:
+    if requests is None:
+        raise RuntimeError("requests library is required for ensure_connection")
     start = time.time()
     try:
         resp = requests.get(url, timeout=timeout, stream=True)


### PR DESCRIPTION
## Summary
- Import `requests` lazily and guard `ensure_connection` when the library is missing
- Silence pytest deprecation warnings by explicitly skipping tests when optional GUI libraries are absent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c2cb65cd948321bf334c2784da3c68