### PR TITLE
Fix log draining in scheduler GUI

### DIFF
--- a/x.py
+++ b/x.py
@@ -977,6 +977,10 @@ class App(tk.Tk):
                 self.log_text.configure(state="disabled")
         except queue.Empty:
             pass
+        finally:
+            # Schedule the next drain so log messages keep flowing
+            # through the GUI while the worker thread is running.
+            self.after(120, self._drain_logs)
 
 
 # ---- Entrypoint


### PR DESCRIPTION
## Summary
- Ensure the GUI continuously drains and displays log messages by rescheduling `_drain_logs`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c2d696fa5c8321b8539280d8d4fd91