### PR TITLE
Fix send reply hotkeys

### DIFF
--- a/tests/test_send_reply.py
+++ b/tests/test_send_reply.py
@@ -1,0 +1,51 @@
+import importlib.util
+import pathlib
+import sys
+
+root = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root))
+spec = importlib.util.spec_from_file_location("x", root / "x.py")
+x = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = x
+spec.loader.exec_module(x)
+
+SchedulerWorker = x.SchedulerWorker
+xsys = x.sys
+xtime = x.time
+
+class DummyKB:
+    def __init__(self):
+        self.calls = []
+    def hotkey(self, *keys):
+        self.calls.append(("hotkey", keys))
+    def press(self, key):
+        self.calls.append(("press", key))
+
+def _make_worker(kb):
+    worker = object.__new__(SchedulerWorker)
+    worker.kb = kb
+    worker._push_to_clipboard = lambda text: None
+    return worker
+
+
+def test_send_reply_linux(monkeypatch):
+    dummy = DummyKB()
+    worker = _make_worker(dummy)
+    monkeypatch.setattr(xsys, "platform", "linux")
+    monkeypatch.setattr(xtime, "sleep", lambda s: None)
+    SchedulerWorker._send_reply(worker, "hi")
+    assert dummy.calls == [
+        ("hotkey", ("ctrl", "v")),
+        ("hotkey", ("ctrl", "enter")),
+    ]
+
+def test_send_reply_macos(monkeypatch):
+    dummy = DummyKB()
+    worker = _make_worker(dummy)
+    monkeypatch.setattr(xsys, "platform", "darwin")
+    monkeypatch.setattr(xtime, "sleep", lambda s: None)
+    SchedulerWorker._send_reply(worker, "hi")
+    assert dummy.calls == [
+        ("hotkey", ("cmd", "v")),
+        ("hotkey", ("cmd", "enter")),
+    ]

--- a/x.py
+++ b/x.py
@@ -31,6 +31,7 @@ import queue
 import random
 import threading
 import logging
+import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, tzinfo
 from typing import List, Tuple, Optional, Dict, Set
@@ -347,9 +348,11 @@ class SchedulerWorker(threading.Thread):
     def _send_reply(self, text: str):
         self._push_to_clipboard(text)
         time.sleep(0.1)
-        self.kb.hotkey("ctrl", "v")
+        key = "cmd" if sys.platform == "darwin" else "ctrl"
+        self.kb.hotkey(key, "v")
         time.sleep(0.1)
-        self.kb.press("enter")
+        # On X/Twitter a reply is sent with Cmd/Ctrl+Enter
+        self.kb.hotkey(key, "enter")
 
     def run(self):
         self._log("INFO", f"Session start {self.session_start} | ends by {self.session_end}")


### PR DESCRIPTION
## Summary
- Detect host platform when sending a reply and use Ctrl/Cmd shortcuts
- Paste reply and submit with the correct modifier+Enter hotkey
- Add tests covering platform-specific reply behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3d372a13c8321afc48a46b0b846bb