### PR TITLE
Normalize key names in keyboard controller

### DIFF
--- a/keyboard_controller.py
+++ b/keyboard_controller.py
@@ -70,8 +70,18 @@ class KeyboardController:
         self._controller = Controller() if Controller else _NoopController()
 
     def _to_key(self, key: str):
-        key = _ALIASES.get(key, key)
-        return getattr(Key, key, key)
+        """Map ``key`` name to ``pynput``'s ``Key`` or return raw value.
+
+        ``pynput`` exposes its special keys in lowercase (e.g. ``Key.enter``),
+        but callers may supply names in any case.  Normalise the incoming name
+        to lowercase before resolving aliases and looking up the ``Key``
+        attribute so that ``"CTRL"``, ``"Ctrl"`` and ``"ctrl"`` all refer to
+        the same key.
+        """
+
+        key_norm = key.lower()
+        key_norm = _ALIASES.get(key_norm, key_norm)
+        return getattr(Key, key_norm, key_norm)
 
     def press(self, key: str, delay: float = 0.0) -> None:
         """Press and release ``key``.

--- a/tests/test_keyboard_controller.py
+++ b/tests/test_keyboard_controller.py
@@ -48,3 +48,16 @@ def test_marks_generated(monkeypatch):
     monkeypatch.setattr(kc, "_controller", dummy)
     kc.press("a")
     assert is_app_generated()
+
+
+def test_case_insensitive(monkeypatch):
+    kc = KeyboardController()
+    dummy = DummyController()
+    monkeypatch.setattr(kc, "_controller", dummy)
+    kc.hotkey("CTRL", "ENTER")
+    assert dummy.events == [
+        ("press", pk.Key.ctrl),
+        ("press", pk.Key.enter),
+        ("release", pk.Key.enter),
+        ("release", pk.Key.ctrl),
+    ]


### PR DESCRIPTION
## Summary
- normalize key names to lower-case before mapping to pynput keys
- test keyboard controller with case-insensitive key names

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3de9325948321878e386102cf616d