### PR TITLE
Simulate typed replies

### DIFF
--- a/tests/test_send_reply.py
+++ b/tests/test_send_reply.py
@@ -20,6 +20,8 @@ class DummyKB:
         self.calls.append(("hotkey", keys))
     def press(self, key, delay=0):
         self.calls.append(("press", key))
+    def typewrite(self, text):
+        self.calls.append(("typewrite", text))
 
 def _make_worker(kb):
     worker = object.__new__(SchedulerWorker)
@@ -35,7 +37,7 @@ def test_send_reply_linux(monkeypatch):
     monkeypatch.setattr(xtime, "sleep", lambda s: None)
     SchedulerWorker._send_reply(worker, "hi")
     assert dummy.calls == [
-        ("hotkey", ("ctrl", "v")),
+        ("typewrite", "hi"),
         ("hotkey", ("ctrl", "enter")),
     ]
 
@@ -46,7 +48,7 @@ def test_send_reply_macos(monkeypatch):
     monkeypatch.setattr(xtime, "sleep", lambda s: None)
     SchedulerWorker._send_reply(worker, "hi")
     assert dummy.calls == [
-        ("hotkey", ("cmd", "v")),
+        ("typewrite", "hi"),
         ("hotkey", ("cmd", "enter")),
     ]
 
@@ -64,6 +66,6 @@ def test_interact_and_reply(monkeypatch):
         ("press", "j"),
         ("press", "l"),
         ("press", "n"),
-        ("hotkey", ("ctrl", "v")),
+        ("typewrite", "hi"),
         ("hotkey", ("ctrl", "enter")),
     ]

--- a/x.py
+++ b/x.py
@@ -366,11 +366,13 @@ class SchedulerWorker(threading.Thread):
             self._log("ERROR", f"Clipboard copy failed: {e}")
 
     def _send_reply(self, text: str):
-        self._push_to_clipboard(text)
+        """Simulate typing ``text`` and submit the reply."""
+
+        # Instead of pasting from the clipboard we type the reply character by
+        # character so the interaction looks more natural on screen.
+        self.kb.typewrite(text)
         time.sleep(0.1)
         key = "cmd" if sys.platform == "darwin" else "ctrl"
-        self.kb.hotkey(key, "v")
-        time.sleep(0.1)
         # On X/Twitter a reply is sent with Cmd/Ctrl+Enter
         self.kb.hotkey(key, "enter")
 


### PR DESCRIPTION
## Summary
- Simulate replying by typing characters instead of using clipboard paste
- Update tests to assert typing behavior via KeyboardController

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c45fce81a883218ec054cff3a7ab13