### PR TITLE
Improve reply typing realism

### DIFF
--- a/tests/test_send_reply.py
+++ b/tests/test_send_reply.py
@@ -20,8 +20,6 @@ class DummyKB:
         self.calls.append(("hotkey", keys))
     def press(self, key, delay=0):
         self.calls.append(("press", key))
-    def typewrite(self, text):
-        self.calls.append(("typewrite", text))
 
 def _make_worker(kb):
     worker = object.__new__(SchedulerWorker)
@@ -37,7 +35,8 @@ def test_send_reply_linux(monkeypatch):
     monkeypatch.setattr(xtime, "sleep", lambda s: None)
     SchedulerWorker._send_reply(worker, "hi")
     assert dummy.calls == [
-        ("typewrite", "hi"),
+        ("press", "h"),
+        ("press", "i"),
         ("hotkey", ("ctrl", "enter")),
     ]
 
@@ -48,7 +47,8 @@ def test_send_reply_macos(monkeypatch):
     monkeypatch.setattr(xtime, "sleep", lambda s: None)
     SchedulerWorker._send_reply(worker, "hi")
     assert dummy.calls == [
-        ("typewrite", "hi"),
+        ("press", "h"),
+        ("press", "i"),
         ("hotkey", ("cmd", "enter")),
     ]
 
@@ -66,6 +66,7 @@ def test_interact_and_reply(monkeypatch):
         ("press", "j"),
         ("press", "l"),
         ("press", "n"),
-        ("typewrite", "hi"),
+        ("press", "h"),
+        ("press", "i"),
         ("hotkey", ("ctrl", "enter")),
     ]

--- a/x.py
+++ b/x.py
@@ -368,9 +368,12 @@ class SchedulerWorker(threading.Thread):
     def _send_reply(self, text: str):
         """Simulate typing ``text`` and submit the reply."""
 
-        # Instead of pasting from the clipboard we type the reply character by
-        # character so the interaction looks more natural on screen.
-        self.kb.typewrite(text)
+        # Type the reply one character at a time to imitate natural typing.
+        for ch in text:
+            self.kb.press(ch)
+            time.sleep(0.05)
+
+        # Small pause before sending the reply.
         time.sleep(0.1)
         key = "cmd" if sys.platform == "darwin" else "ctrl"
         # On X/Twitter a reply is sent with Cmd/Ctrl+Enter


### PR DESCRIPTION
## Summary
- Type replies character-by-character with slight delay
- Send replies using Cmd/Ctrl+Enter after typing
- Update tests for per-character typing behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4626ddd708321b57d276cb2174f99