### PR TITLE
Add keystroke miss chance and slower typing to controller

### DIFF
--- a/keyboard_controller.py
+++ b/keyboard_controller.py
@@ -1,4 +1,5 @@
 import time
+import random
 
 try:  # pragma: no cover - optional dependency
     from pynput.keyboard import Controller, Key
@@ -123,8 +124,29 @@ class KeyboardController:
                 _mark_generated()
                 self._controller.release(k)
 
-    def typewrite(self, text: str, interval: float = 0.0) -> None:
+    def typewrite(
+        self,
+        text: str,
+        interval: float = 0.05,
+        miss_chance: float = 0.0,
+    ) -> None:
+        """Type ``text`` character by character.
+
+        Parameters
+        ----------
+        text:
+            Text to type.
+        interval:
+            Delay between key presses.  Defaults to ``0.05`` seconds which
+            produces slightly slower, more human-like typing.
+        miss_chance:
+            Probability in the range ``[0.0, 1.0]`` that an individual
+            character is skipped entirely to simulate a missed keystroke.
+        """
+
         for ch in text:
+            if miss_chance and random.random() < miss_chance:
+                continue
             self.press(ch)
             if interval:
                 time.sleep(interval)

--- a/tests/test_keyboard_controller.py
+++ b/tests/test_keyboard_controller.py
@@ -33,13 +33,21 @@ def test_typewrite(monkeypatch):
     kc = KeyboardController()
     dummy = DummyController()
     monkeypatch.setattr(kc, "_controller", dummy)
-    kc.typewrite("ab")
+    kc.typewrite("ab", interval=0)
     assert dummy.events == [
         ("press", "a"),
         ("release", "a"),
         ("press", "b"),
         ("release", "b"),
     ]
+
+
+def test_typewrite_miss_chance(monkeypatch):
+    kc = KeyboardController()
+    dummy = DummyController()
+    monkeypatch.setattr(kc, "_controller", dummy)
+    kc.typewrite("abc", interval=0, miss_chance=1.0)
+    assert dummy.events == []
 
 
 def test_marks_generated(monkeypatch):


### PR DESCRIPTION
## Summary
- Make `KeyboardController.typewrite` support default slow typing and optional keystroke miss probability
- Test new miss chance behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c47aab8bd8832182ff10df5ab33d06