### PR TITLE
Add keystroke miss chance and jittery slow typing

### DIFF
--- a/keyboard_controller.py
+++ b/keyboard_controller.py
@@ -1,4 +1,5 @@
 import time
+import random
 
 try:  # pragma: no cover - optional dependency
     from pynput.keyboard import Controller, Key
@@ -123,8 +124,38 @@ class KeyboardController:
                 _mark_generated()
                 self._controller.release(k)
 
-    def typewrite(self, text: str, interval: float = 0.0) -> None:
+    def typewrite(
+        self,
+        text: str,
+        interval: float = 0.2,
+        miss_chance: float = 0.0,
+        jitter: float = 0.1,
+    ) -> None:
+        """Type ``text`` character by character.
+
+        Parameters
+        ----------
+        text:
+            Text to type.
+        interval:
+            Base delay between key presses.  Defaults to ``0.2`` seconds for
+            a noticeably slow typing speed.
+        miss_chance:
+            Probability in the range ``[0.0, 1.0]`` that an individual
+            character is skipped entirely to simulate a missed keystroke.
+        jitter:
+            Additional random variation added to ``interval``.  Each delay is
+            adjusted by ``random.uniform(-jitter, jitter)`` so successive
+            keystrokes are unevenly spaced.  Ignored if ``interval`` is ``0``.
+        """
         for ch in text:
+            if miss_chance and random.random() < miss_chance:
+                continue
             self.press(ch)
             if interval:
-                time.sleep(interval)
+                delay = interval
+                if jitter:
+                    delay += random.uniform(-jitter, jitter)
+                    if delay < 0:
+                        delay = 0
+                time.sleep(delay)

--- a/tests/test_keyboard_controller.py
+++ b/tests/test_keyboard_controller.py
@@ -1,4 +1,6 @@
 import pytest
+import time
+import random
 pk = pytest.importorskip(
     "pynput.keyboard", reason="requires pynput", exc_type=ImportError
 )
@@ -33,13 +35,32 @@ def test_typewrite(monkeypatch):
     kc = KeyboardController()
     dummy = DummyController()
     monkeypatch.setattr(kc, "_controller", dummy)
-    kc.typewrite("ab")
+    kc.typewrite("ab", interval=0)
     assert dummy.events == [
         ("press", "a"),
         ("release", "a"),
         ("press", "b"),
         ("release", "b"),
     ]
+
+
+def test_typewrite_miss_chance(monkeypatch):
+    kc = KeyboardController()
+    dummy = DummyController()
+    monkeypatch.setattr(kc, "_controller", dummy)
+    kc.typewrite("abc", interval=0, miss_chance=1.0)
+    assert dummy.events == []
+
+
+def test_typewrite_jitter(monkeypatch):
+    kc = KeyboardController()
+    dummy = DummyController()
+    monkeypatch.setattr(kc, "_controller", dummy)
+    sleeps = []
+    monkeypatch.setattr(time, "sleep", lambda s: sleeps.append(s))
+    monkeypatch.setattr(random, "uniform", lambda a, b: b)
+    kc.typewrite("ab", interval=0.2, jitter=0.1)
+    assert sleeps == [0.3, 0.3]
 
 
 def test_marks_generated(monkeypatch):


### PR DESCRIPTION
## Summary
- Slow default typing to 0.2s per key and add configurable jitter for uneven delays
- Test jitter behavior alongside existing miss chance tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c47aab8bd8832182ff10df5ab33d06