### PR TITLE
Add night sleep window handling to PostScheduler

### DIFF
--- a/post_scheduler.py
+++ b/post_scheduler.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Optional
+
+
+class PostScheduler:
+    """Simple helper for scheduling posts with a night sleep window.
+
+    Parameters
+    ----------
+    night_sleep_start:
+        Start of the daily window during which no posts should be scheduled.
+    night_sleep_end:
+        End of the sleep window.
+    """
+
+    def __init__(self, night_sleep_start: datetime, night_sleep_end: datetime):
+        self.night_sleep_start = night_sleep_start
+        self.night_sleep_end = night_sleep_end
+        self.next_post: Optional[datetime] = None
+
+    def schedule_next(self, now: datetime, delay: timedelta) -> datetime:
+        """Schedule the next post after ``delay`` seconds.
+
+        If ``now`` falls within the configured night sleep window, the post is
+        delayed until ``night_sleep_end`` plus ``delay``.  Otherwise, the post
+        is scheduled ``delay`` after ``now``.
+        """
+
+        if self.night_sleep_start <= now <= self.night_sleep_end:
+            scheduled = self.night_sleep_end + delay
+        else:
+            scheduled = now + delay
+        self.next_post = scheduled
+        return scheduled

--- a/tests/test_post_scheduler.py
+++ b/tests/test_post_scheduler.py
@@ -1,0 +1,33 @@
+import importlib.util
+import pathlib
+import sys
+from datetime import datetime, timedelta
+
+root = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root))
+
+from post_scheduler import PostScheduler
+
+
+def _dt(hour, minute=0):
+    return datetime(2024, 1, 1, hour, minute)
+
+
+def test_schedule_outside_sleep():
+    start = _dt(22)
+    end = datetime(2024, 1, 2, 6, 0)
+    sched = PostScheduler(start, end)
+    now = _dt(12)
+    next_time = sched.schedule_next(now, timedelta(hours=1))
+    assert sched.night_sleep_start == start
+    assert sched.night_sleep_end == end
+    assert next_time == now + timedelta(hours=1)
+
+
+def test_schedule_during_sleep_delays_until_end():
+    start = _dt(22)
+    end = datetime(2024, 1, 2, 6, 0)
+    sched = PostScheduler(start, end)
+    now = datetime(2024, 1, 1, 23, 30)
+    next_time = sched.schedule_next(now, timedelta(hours=1))
+    assert next_time == end + timedelta(hours=1)


### PR DESCRIPTION
## Summary
- Implement `PostScheduler` class with configurable night sleep window and delayed scheduling when within the window
- Add unit tests for normal scheduling and behavior during the sleep period

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c47acad2608321b58829148b6d7ec4