### PR TITLE
Add post scheduler with interval config

### DIFF
--- a/tests/test_post_scheduler.py
+++ b/tests/test_post_scheduler.py
@@ -1,0 +1,33 @@
+import importlib.util
+import pathlib
+import sys
+import threading
+
+root = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root))
+spec = importlib.util.spec_from_file_location("x", root / "x.py")
+x = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = x
+spec.loader.exec_module(x)
+
+PostScheduler = x.PostScheduler
+
+def test_post_scheduler_pauses_and_resumes():
+    pause = threading.Event()
+    stop = threading.Event()
+    calls = []
+    def cb():
+        calls.append(pause.is_set())
+    ps = PostScheduler(1, pause, stop, cb)
+    ps._trigger_post()
+    assert calls == [True]
+    assert not pause.is_set()
+
+def test_post_scheduler_handles_cancel():
+    pause = threading.Event()
+    stop = threading.Event()
+    def cb():
+        raise RuntimeError("cancelled")
+    ps = PostScheduler(1, pause, stop, cb)
+    ps._trigger_post()
+    assert not pause.is_set()


### PR DESCRIPTION
## Summary
- add `post_interval_minutes` setting to configuration and profile handling
- implement `PostScheduler` that pauses reply flow while posting
- add tests for post scheduler pause/resume logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c47ad01c7c83218df7cf5bdc8234df