### PR TITLE
Ensure typewriter corrects simulated mistakes

### DIFF
--- a/tests/test_keyboard_controller.py
+++ b/tests/test_keyboard_controller.py
@@ -48,8 +48,28 @@ def test_typewrite_miss_chance(monkeypatch):
     kc = KeyboardController()
     dummy = DummyController()
     monkeypatch.setattr(kc, "_controller", dummy)
+    monkeypatch.setattr(random, "random", lambda: 0.0)
     kc.typewrite("abc", interval=0, miss_chance=1.0)
-    assert dummy.events == []
+    assert dummy.events == [
+        ("press", "a"),
+        ("release", "a"),
+        ("press", pk.Key.backspace),
+        ("release", pk.Key.backspace),
+        ("press", "a"),
+        ("release", "a"),
+        ("press", "b"),
+        ("release", "b"),
+        ("press", pk.Key.backspace),
+        ("release", pk.Key.backspace),
+        ("press", "b"),
+        ("release", "b"),
+        ("press", "c"),
+        ("release", "c"),
+        ("press", pk.Key.backspace),
+        ("release", pk.Key.backspace),
+        ("press", "c"),
+        ("release", "c"),
+    ]
 
 
 


### PR DESCRIPTION
## Summary
- ensure `KeyboardController.typewrite` clamps miss chance values, reuses a jitter helper, and corrects simulated mistakes by deleting and retyping characters instead of dropping them
- update the keyboard controller tests to cover the new correction behaviour when `miss_chance` is triggered

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c936ad12b8832197670fa942cfa2d9