### PR TITLE
Update reply interaction key

### DIFF
--- a/tests/test_send_reply.py
+++ b/tests/test_send_reply.py
@@ -65,7 +65,7 @@ def test_interact_and_reply(monkeypatch):
     SchedulerWorker._interact_and_reply(worker, "hi")
     assert dummy.calls == [
         ("press", "l"),
-        ("press", "n"),
+        ("press", "r"),
         ("press", "h"),
         ("press", "i"),
         ("hotkey", ("ctrl", "enter")),

--- a/x.py
+++ b/x.py
@@ -444,7 +444,7 @@ class SchedulerWorker(threading.Thread):
         time.sleep(random.uniform(0.2, 0.35))
         self.kb.press("l")
         time.sleep(random.uniform(0.2, 0.35))
-        self.kb.press("n")
+        self.kb.press("r")
         time.sleep(0.5)
         self._send_reply(text)
 


### PR DESCRIPTION
## Summary
- update `SchedulerWorker._interact_and_reply` to press the "r" key when triggering replies
- adjust the `test_interact_and_reply` expectation to match the new key sequence

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c971598ae483218b3768a91ecf410b