### PR TITLE
Reset search open tracking each work step

### DIFF
--- a/tests/test_send_reply.py
+++ b/tests/test_send_reply.py
@@ -91,3 +91,22 @@ def test_press_j_batch(monkeypatch):
         ("press", "j"),
         ("press", "j"),
     ]
+
+
+def test_reset_step_open_state_clears_sections_once_per_section():
+    dummy = DummyKB()
+    worker = _make_worker(dummy)
+    worker.search_open_policy = "once_per_section"
+    worker._opened_sections = set()
+    worker._opened_this_step = False
+
+    assert worker._should_open_search_now("alpha") is True
+
+    worker._mark_opened("alpha")
+    assert worker._should_open_search_now("alpha") is False
+
+    SchedulerWorker._reset_step_open_state(worker)
+
+    assert worker._opened_sections == set()
+    assert worker._opened_this_step is False
+    assert worker._should_open_search_now("alpha") is True

--- a/x.py
+++ b/x.py
@@ -364,7 +364,10 @@ class SchedulerWorker(threading.Thread):
             pass
 
     def _reset_step_open_state(self):
+        """Reset per-step tracking of opened search sections."""
+
         self._opened_this_step = False
+        self._opened_sections.clear()
 
     def _open_search(self, query: str, section_name: str):
         url = build_search_url(query, self.search_mode)


### PR DESCRIPTION
## Summary
- clear the per-step section tracking when beginning a work step so the once_per_section policy resets each time
- document the reset helper and cover the behavior with a unit test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c978665ebc8321a103825dadacffef