### PR TITLE
Type URLs instantly when reusing browser tabs

### DIFF
--- a/x.py
+++ b/x.py
@@ -387,7 +387,7 @@ class SchedulerWorker(threading.Thread):
                 key = "cmd" if sys.platform == "darwin" else "ctrl"
                 self.kb.hotkey(key, "l")
                 time.sleep(0.1)
-                self.kb.typewrite(url)
+                self.kb.typewrite(url, interval=0, jitter=0)
                 self.kb.press("enter")
         except Exception as e:
             self._log("ERROR", f"Browser navigation failed: {e}")


### PR DESCRIPTION
## Summary
- type URLs into the location bar without simulated typing delay when reusing an existing browser window

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c9b6dadbec83218249c3fa9946ed55