### PR TITLE
Add natural pauses between reply workflow steps

### DIFF
--- a/tests/test_send_reply.py
+++ b/tests/test_send_reply.py
@@ -14,6 +14,8 @@ spec.loader.exec_module(x)
 SchedulerWorker = x.SchedulerWorker
 xsys = x.sys
 xtime = x.time
+STEP_PAUSE_MIN = x.STEP_PAUSE_MIN
+STEP_PAUSE_MAX = x.STEP_PAUSE_MAX
 
 class DummyKB:
     def __init__(self):
@@ -77,9 +79,11 @@ def test_press_j_batch(monkeypatch):
     worker = _make_worker(dummy)
     monkeypatch.setattr(x.random, "randint", lambda a, b: 3)
 
-    delays = iter([0.2, 0.21, 0.22])
+    delays = iter([0.6, 1.1, 0.9])
+    calls = []
 
     def fake_uniform(a, b):
+        calls.append((a, b))
         return next(delays)
 
     monkeypatch.setattr(x.random, "uniform", fake_uniform)
@@ -91,6 +95,7 @@ def test_press_j_batch(monkeypatch):
         ("press", "j"),
         ("press", "j"),
     ]
+    assert calls == [(STEP_PAUSE_MIN, STEP_PAUSE_MAX)] * 3
 
 
 def test_reset_step_open_state_clears_sections_once_per_section():

--- a/x.py
+++ b/x.py
@@ -83,6 +83,10 @@ def similarity_ratio(a: str, b: str) -> float:
 BASE_WAIT = 3
 MAX_WAIT = 15
 
+# Natural pauses inserted between high-level actions to mimic human pacing.
+STEP_PAUSE_MIN = 0.5
+STEP_PAUSE_MAX = 1.8
+
 
 def ensure_connection(url: str, timeout: float) -> float:
     """Check connectivity to ``url`` and return the request time.
@@ -423,7 +427,7 @@ class SchedulerWorker(threading.Thread):
             time.sleep(0.05)
 
         # Small pause before sending the reply.
-        time.sleep(0.1)
+        time.sleep(random.uniform(STEP_PAUSE_MIN, STEP_PAUSE_MAX))
         key = "cmd" if sys.platform == "darwin" else "ctrl"
         # On X/Twitter a reply is sent with Cmd/Ctrl+Enter
         self.kb.hotkey(key, "enter")
@@ -436,7 +440,7 @@ class SchedulerWorker(threading.Thread):
             if stop_event and stop_event.is_set():
                 return False
             self.kb.press("j")
-            delay = random.uniform(0.18, 0.35)
+            delay = random.uniform(STEP_PAUSE_MIN, STEP_PAUSE_MAX)
             if stop_event:
                 self._pauseable_sleep(delay, chunk=0.1)
             else:
@@ -444,11 +448,11 @@ class SchedulerWorker(threading.Thread):
         return True
 
     def _interact_and_reply(self, text: str):
-        time.sleep(random.uniform(0.2, 0.35))
+        time.sleep(random.uniform(STEP_PAUSE_MIN, STEP_PAUSE_MAX))
         self.kb.press("l")
-        time.sleep(random.uniform(0.2, 0.35))
+        time.sleep(random.uniform(STEP_PAUSE_MIN, STEP_PAUSE_MAX))
         self.kb.press("r")
-        time.sleep(0.5)
+        time.sleep(random.uniform(STEP_PAUSE_MIN, STEP_PAUSE_MAX))
         self._send_reply(text)
 
     def run(self):


### PR DESCRIPTION
## Summary
- add shared step pause range constants to slow navigation and reply actions
- apply the 0.5–1.8s pauses between browsing, replying, and confirmation steps
- update the unit test to assert the new delay range is used

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9bfa4f7608321b5e2a0d3cdc7f9f8