### PR TITLE
Add RSS ingestion service and news storage

### DIFF
--- a/news_library.py
+++ b/news_library.py
@@ -1,0 +1,102 @@
+"""Persistent store for RSS items with simple deduplication helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from typing import Dict, Iterable, List
+
+
+class NewsLibrary:
+    """Manage a collection of RSS items persisted to a JSON file.
+
+    The library keeps track of previously ingested articles using a combination
+    of their identifier and published timestamp.  This makes it resilient
+    against feeds that occasionally recycle identifiers but emit a new
+    timestamp when an article is updated.
+    """
+
+    def __init__(self, path: str | os.PathLike[str] | None = None) -> None:
+        base_dir = os.path.abspath(os.path.dirname(__file__))
+        if path is None:
+            base_dir = os.path.join(base_dir, "configs")
+            os.makedirs(base_dir, exist_ok=True)
+            path = os.path.join(base_dir, "news.json")
+
+        self.path = str(path)
+        os.makedirs(os.path.dirname(self.path), exist_ok=True)
+
+        self._lock = threading.Lock()
+        self._items: List[Dict] = []
+        self._seen: set[str] = set()
+        self.load()
+
+    # ------------------------------------------------------------------
+    def load(self) -> List[Dict]:
+        """Load stored items from :attr:`path`.  Missing files are created."""
+
+        try:
+            with open(self.path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            if isinstance(data, list):
+                self._items = list(data)
+            else:  # pragma: no cover - corrupted file
+                self._items = []
+        except FileNotFoundError:
+            self._items = []
+            self.save()
+        except Exception:  # pragma: no cover - unexpected parse failure
+            self._items = []
+
+        self._rebuild_index()
+        return list(self._items)
+
+    def save(self) -> None:
+        """Persist the current items to :attr:`path`."""
+
+        with open(self.path, "w", encoding="utf-8") as fh:
+            json.dump(self._items, fh, ensure_ascii=False, indent=2)
+
+    # ------------------------------------------------------------------
+    def _rebuild_index(self) -> None:
+        self._seen = {self._dedup_key(item) for item in self._items}
+
+    def _dedup_key(self, item: Dict) -> str:
+        ident = str(item.get("id") or item.get("link") or item.get("title") or "").strip()
+        published = item.get("published") or ""
+        return f"{ident}|{published}"
+
+    # ------------------------------------------------------------------
+    def get_items(self) -> List[Dict]:
+        """Return a shallow copy of stored articles."""
+
+        with self._lock:
+            return list(self._items)
+
+    def add_items(self, items: Iterable[Dict]) -> int:
+        """Add ``items`` to the library, skipping entries already seen.
+
+        Returns the number of newly inserted items.
+        """
+
+        inserted = 0
+        with self._lock:
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                key = self._dedup_key(item)
+                if key in self._seen:
+                    continue
+                self._seen.add(key)
+                self._items.append(dict(item))
+                inserted += 1
+
+            if inserted:
+                self._items.sort(
+                    key=lambda it: str(it.get("published") or ""), reverse=True
+                )
+                self.save()
+
+        return inserted
+

--- a/rss_ingestor.py
+++ b/rss_ingestor.py
@@ -1,0 +1,253 @@
+"""Background thread that periodically ingests RSS feeds."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from datetime import datetime, timedelta, timezone
+from email.utils import parsedate_to_datetime
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence
+from xml.etree import ElementTree as ET
+
+try:  # pragma: no cover - keep optional dependency soft
+    import requests
+except Exception:  # pragma: no cover - requests may be unavailable
+    requests = None  # type: ignore[assignment]
+
+DEFAULT_INTERVAL_SECONDS = 4 * 60 * 60  # 4 hours
+
+
+def _local_name(tag: str) -> str:
+    if "}" in tag:
+        return tag.rsplit("}", 1)[-1]
+    return tag
+
+
+def _find_direct_text(node: ET.Element, names: Iterable[str]) -> str:
+    targets = set(names)
+    for child in node:
+        if _local_name(child.tag) in targets:
+            text = child.text or ""
+            text = text.strip()
+            if text:
+                return text
+    return ""
+
+
+def _find_any_text(node: ET.Element, names: Iterable[str]) -> str:
+    targets = set(names)
+    for child in node.iter():
+        if _local_name(child.tag) in targets:
+            text = child.text or ""
+            text = text.strip()
+            if text:
+                return text
+    return ""
+
+
+def _find_link(node: ET.Element) -> str:
+    for child in node.iter():
+        if _local_name(child.tag) != "link":
+            continue
+        href = child.attrib.get("href") if hasattr(child, "attrib") else None
+        if href:
+            return href.strip()
+        text = child.text or ""
+        text = text.strip()
+        if text:
+            return text
+    return ""
+
+
+def _parse_datetime(value: str | None) -> Optional[datetime]:
+    if not value:
+        return None
+
+    value = value.strip()
+    if not value:
+        return None
+
+    for parser in (_from_isoformat, _from_email_date):
+        dt = parser(value)
+        if dt is not None:
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt.astimezone(timezone.utc)
+    return None
+
+
+def _from_isoformat(value: str) -> Optional[datetime]:
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _from_email_date(value: str) -> Optional[datetime]:
+    try:
+        dt = parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    return dt
+
+
+def _normalise_entry(entry: ET.Element, source_url: str) -> Dict[str, Any]:
+    title = _find_direct_text(entry, {"title"}) or _find_any_text(entry, {"title"})
+    summary = _find_direct_text(entry, {"summary", "description"})
+    if not summary:
+        summary = _find_any_text(entry, {"summary", "description", "content"})
+
+    link = _find_link(entry)
+    identifier = _find_direct_text(entry, {"id", "guid"})
+    if not identifier:
+        identifier = _find_any_text(entry, {"id", "guid"})
+    published_raw = _find_direct_text(entry, {"published", "pubDate", "updated"})
+    if not published_raw:
+        published_raw = _find_any_text(entry, {"published", "pubDate", "updated"})
+
+    published_dt = _parse_datetime(published_raw)
+    if published_dt is None:
+        published_dt = datetime.now(timezone.utc)
+    published_iso = published_dt.isoformat()
+
+    if not identifier:
+        identifier = link or f"{title}:{published_iso}"
+
+    return {
+        "id": identifier,
+        "title": title,
+        "summary": summary,
+        "link": link,
+        "published": published_iso,
+        "source": source_url,
+        "fetched_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def parse_feed(document: str, source_url: str) -> List[Dict[str, Any]]:
+    """Parse ``document`` and return normalised feed entries."""
+
+    try:
+        root = ET.fromstring(document)
+    except ET.ParseError:
+        logging.warning("rss_ingestor: failed to parse feed from %s", source_url)
+        return []
+
+    items: List[ET.Element] = []
+
+    channel = root.find("channel")
+    if channel is not None:
+        items.extend(channel.findall("item"))
+    if not items:
+        items.extend(root.findall(".//item"))
+    if not items:
+        items.extend(root.findall(".//{*}entry"))
+    if not items:
+        items.extend(root.findall("entry"))
+
+    normalised: List[Dict[str, Any]] = []
+    for entry in items:
+        try:
+            normalised.append(_normalise_entry(entry, source_url))
+        except Exception:  # pragma: no cover - defensive against malformed feeds
+            logging.exception("rss_ingestor: failed to normalise entry from %s", source_url)
+    return normalised
+
+
+class RSSIngestor(threading.Thread):
+    """Background worker that polls RSS feeds and stores new entries."""
+
+    def __init__(
+        self,
+        feeds: Sequence[str],
+        library,
+        interval_seconds: float = DEFAULT_INTERVAL_SECONDS,
+        stop_event: Optional[threading.Event] = None,
+        pause_event: Optional[threading.Event] = None,
+        status_callback: Optional[Callable[[Optional[datetime], Optional[datetime], bool], None]] = None,
+        fetcher: Optional[Callable[[str], str]] = None,
+        request_timeout: float = 10.0,
+    ) -> None:
+        super().__init__(daemon=True)
+        self.feeds = [f for f in feeds if f]
+        self.library = library
+        self.interval_seconds = max(60.0, float(interval_seconds))
+        self.stop_event = stop_event or threading.Event()
+        self.pause_event = pause_event
+        self.status_callback = status_callback
+        self._fetcher = fetcher
+        self.request_timeout = request_timeout
+        self.last_fetch: Optional[datetime] = None
+        self.next_fetch: Optional[datetime] = None
+        self._was_paused = False
+
+    # ------------------------------------------------------------------
+    def run(self) -> None:  # pragma: no cover - exercised indirectly in tests
+        self.next_fetch = datetime.now(timezone.utc)
+        self._notify_status(paused=False)
+
+        while not self.stop_event.is_set():
+            if self.pause_event is not None and self.pause_event.is_set():
+                if not self._was_paused:
+                    self._notify_status(paused=True)
+                    self._was_paused = True
+                if self.stop_event.wait(1.0):
+                    break
+                continue
+
+            self._was_paused = False
+            self._ingest_once()
+            if self.stop_event.wait(self.interval_seconds):
+                break
+
+    # ------------------------------------------------------------------
+    def _ingest_once(self) -> None:
+        items = self.fetch_once()
+        if items:
+            try:
+                self.library.add_items(items)
+            except Exception:  # pragma: no cover - persistence errors are rare
+                logging.exception("rss_ingestor: failed to persist items")
+
+        self.last_fetch = datetime.now(timezone.utc)
+        self.next_fetch = self.last_fetch + timedelta(seconds=self.interval_seconds)
+        self._notify_status(paused=False)
+
+    def fetch_once(self) -> List[Dict[str, Any]]:
+        """Download and parse each configured feed once."""
+
+        collected: List[Dict[str, Any]] = []
+        for url in self.feeds:
+            try:
+                document = self._download(url)
+            except Exception as exc:  # pragma: no cover - network dependent
+                logging.warning("rss_ingestor: failed to fetch %s: %s", url, exc)
+                continue
+
+            entries = parse_feed(document, url)
+            collected.extend(entries)
+
+        return collected
+
+    # ------------------------------------------------------------------
+    def _download(self, url: str) -> str:
+        if self._fetcher is not None:
+            return self._fetcher(url)
+
+        if requests is None:
+            raise RuntimeError("requests dependency is not available")
+
+        resp = requests.get(url, timeout=self.request_timeout)
+        resp.raise_for_status()
+        resp.encoding = resp.encoding or "utf-8"
+        return resp.text
+
+    # ------------------------------------------------------------------
+    def _notify_status(self, paused: bool) -> None:
+        if self.status_callback is None:
+            return
+        try:
+            self.status_callback(self.last_fetch, self.next_fetch, paused)
+        except Exception:  # pragma: no cover - UI callback failure should not kill thread
+            logging.exception("rss_ingestor: status callback failed")
+

--- a/tests/test_rss_ingestor.py
+++ b/tests/test_rss_ingestor.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from news_library import NewsLibrary
+from rss_ingestor import RSSIngestor
+
+
+SAMPLE_FEED = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Example Feed</title>
+    <item>
+      <guid>item-1</guid>
+      <title>First entry</title>
+      <link>https://example.com/first</link>
+      <pubDate>Tue, 02 Jan 2024 12:00:00 GMT</pubDate>
+      <description>First summary</description>
+    </item>
+    <item>
+      <guid>item-2</guid>
+      <title>Second entry</title>
+      <link>https://example.com/second</link>
+      <pubDate>Mon, 01 Jan 2024 08:00:00 GMT</pubDate>
+      <description>Second summary</description>
+    </item>
+  </channel>
+</rss>
+"""
+
+
+def test_news_library_deduplicates(tmp_path):
+    path = tmp_path / "news.json"
+    library = NewsLibrary(str(path))
+
+    item = {
+        "id": "item-1",
+        "title": "First entry",
+        "summary": "First summary",
+        "link": "https://example.com/first",
+        "published": datetime(2024, 1, 2, 12, 0, tzinfo=timezone.utc).isoformat(),
+    }
+
+    assert library.add_items([item]) == 1
+    assert library.add_items([dict(item)]) == 0
+
+    stored = library.get_items()
+    assert len(stored) == 1
+    assert stored[0]["id"] == "item-1"
+
+    # Reload from disk to ensure persistence
+    library_reloaded = NewsLibrary(str(path))
+    assert library_reloaded.get_items()[0]["id"] == "item-1"
+
+
+def test_rss_ingestor_fetch_once(tmp_path):
+    path = tmp_path / "news.json"
+    library = NewsLibrary(str(path))
+
+    def fake_fetcher(url: str) -> str:
+        assert url == "https://example.com/feed"
+        return SAMPLE_FEED
+
+    ingestor = RSSIngestor(
+        ["https://example.com/feed"],
+        library,
+        interval_seconds=60,
+        fetcher=fake_fetcher,
+    )
+
+    items = ingestor.fetch_once()
+    assert len(items) == 2
+    assert {item["id"] for item in items} == {"item-1", "item-2"}
+    assert all(item["link"].startswith("https://example.com/") for item in items)
+    assert all("summary" in item for item in items)
+
+    inserted = library.add_items(items)
+    assert inserted == 2
+
+    # Items should be sorted newest first
+    stored = library.get_items()
+    assert stored[0]["id"] == "item-1"
+    assert stored[1]["id"] == "item-2"
+
+    # Adding the same items again should be ignored
+    assert library.add_items(items) == 0
+
+    library_reloaded = NewsLibrary(str(path))
+    assert len(library_reloaded.get_items()) == 2


### PR DESCRIPTION
## Summary
- add a persistent `NewsLibrary` for deduplicated RSS entries and an `RSSIngestor` background worker
- integrate RSS configuration and status indicators into the main application lifecycle
- cover ingestion and storage behaviour with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca5ffd6144832192d598d5202b6c88