### PR TITLE
Add OpenAI summariser integration for RSS posts

### DIFF
--- a/llm_client.py
+++ b/llm_client.py
@@ -1,0 +1,217 @@
+"""Helpers for using an LLM to summarise RSS items for posting."""
+
+from __future__ import annotations
+
+import logging
+import textwrap
+from typing import Any, Dict, Iterable, List, Optional
+
+try:  # Optional dependency -- the rest of the project also treats it as optional
+    import requests
+except Exception:  # pragma: no cover - keep import errors from breaking the module
+    requests = None  # type: ignore[assignment]
+
+DEFAULT_MODEL = "gpt-3.5-turbo"
+DEFAULT_BASE_URL = "https://api.openai.com/v1"
+DEFAULT_TONE = "Confident, constructive, and optimistic while staying respectful."
+DEFAULT_TEMPERATURE = 0.6
+DEFAULT_TIMEOUT = 15.0
+
+
+def load_llm_settings(settings: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Return OpenAI configuration extracted from ``settings``.
+
+    The UI provides three user editable values: persona text, maximum character
+    length and the API key.  Optional advanced values (model, base URL, etc.)
+    may be passed through ``settings`` as well.  When the mandatory values are
+    missing ``None`` is returned so callers can fall back to the legacy
+    behaviour.
+    """
+
+    if not isinstance(settings, dict):
+        return None
+
+    persona_text = str(settings.get("rss_persona_text", "") or "").strip()
+    api_key = str(settings.get("openai_api_key", "") or "").strip()
+
+    max_length_raw = settings.get("rss_max_post_length")
+    max_length: Optional[int]
+    if isinstance(max_length_raw, (int, float)):
+        max_length = int(max_length_raw)
+    elif isinstance(max_length_raw, str):
+        try:
+            max_length = int(max_length_raw.strip())
+        except ValueError:
+            max_length = None
+    else:
+        max_length = None
+
+    if not persona_text or not api_key:
+        return None
+
+    if max_length is None or max_length <= 0:
+        max_length = 280
+
+    base_url = str(settings.get("openai_base_url") or DEFAULT_BASE_URL).strip() or DEFAULT_BASE_URL
+    model = str(settings.get("openai_model") or DEFAULT_MODEL).strip() or DEFAULT_MODEL
+
+    tone = str(settings.get("rss_persona_tone") or "").strip()
+    if not tone:
+        tone = DEFAULT_TONE
+
+    temperature_raw = settings.get("openai_temperature")
+    try:
+        temperature = float(temperature_raw)
+    except (TypeError, ValueError):
+        temperature = DEFAULT_TEMPERATURE
+
+    timeout_raw = settings.get("openai_timeout")
+    try:
+        timeout = float(timeout_raw)
+        if timeout <= 0:
+            raise ValueError
+    except (TypeError, ValueError):
+        timeout = DEFAULT_TIMEOUT
+
+    return {
+        "api_key": api_key,
+        "persona_text": persona_text,
+        "max_length": max_length,
+        "model": model,
+        "base_url": base_url,
+        "tone": tone,
+        "temperature": temperature,
+        "timeout": timeout,
+    }
+
+
+def summarize_rss_item(rss_item: Dict[str, Any], persona_settings: Dict[str, Any]) -> str:
+    """Call the OpenAI chat completion API and return generated post text."""
+
+    if requests is None:
+        raise RuntimeError("requests dependency is required for OpenAI API calls")
+
+    api_key = persona_settings.get("api_key")
+    if not api_key:
+        raise ValueError("persona_settings missing 'api_key'")
+
+    prompt = _build_prompt(rss_item, persona_settings)
+
+    payload = {
+        "model": persona_settings.get("model", DEFAULT_MODEL),
+        "messages": [
+            {
+                "role": "system",
+                "content": (
+                    "You are a social media editor who writes concise, opinionated "
+                    "posts for X/Twitter based on article summaries."
+                ),
+            },
+            {"role": "user", "content": prompt},
+        ],
+        "temperature": float(persona_settings.get("temperature", DEFAULT_TEMPERATURE)),
+    }
+
+    base_url = str(persona_settings.get("base_url") or DEFAULT_BASE_URL).rstrip("/")
+    if not base_url:
+        base_url = DEFAULT_BASE_URL.rstrip("/")
+    url = f"{base_url}/chat/completions"
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    timeout = float(persona_settings.get("timeout", DEFAULT_TIMEOUT))
+
+    logging.debug("Calling OpenAI API at %s", url)
+    response = requests.post(url, headers=headers, json=payload, timeout=timeout)
+    response.raise_for_status()
+    data = response.json()
+
+    choices = data.get("choices") or []
+    for choice in choices:
+        message = choice.get("message") or {}
+        content = message.get("content")
+        if content:
+            return content.strip()
+
+    raise RuntimeError("OpenAI response did not contain generated content")
+
+
+def _build_prompt(rss_item: Dict[str, Any], persona_settings: Dict[str, Any]) -> str:
+    """Construct the prompt passed to the model."""
+
+    meta_fields: List[tuple[str, Iterable[str]]] = [
+        ("Title", ("title",)),
+        ("Summary", ("summary", "description")),
+        ("Published", ("published", "updated")),
+        ("Link", ("link",)),
+        ("Source", ("source",)),
+    ]
+
+    lines: List[str] = []
+    for label, keys in meta_fields:
+        value = _first_non_empty(rss_item, keys)
+        if value:
+            lines.append(f"{label}: {value}")
+
+    tags = rss_item.get("tags")
+    if isinstance(tags, (list, tuple)) and tags:
+        lines.append(f"Tags: {', '.join(str(t) for t in tags if str(t).strip())}")
+    elif isinstance(tags, str) and tags.strip():
+        lines.append(f"Tags: {tags.strip()}")
+
+    if not lines:
+        title = rss_item.get("title")
+        if title:
+            lines.append(f"Title: {title}")
+        else:
+            lines.append("(No metadata supplied beyond the raw item.)")
+
+    persona_text = str(persona_settings.get("persona_text", "")).strip()
+    if not persona_text:
+        persona_text = "Use a pragmatic founder voice that adds concise, actionable opinion."
+
+    max_length = int(persona_settings.get("max_length", 280))
+    tone = persona_settings.get("tone", DEFAULT_TONE)
+
+    guardrails = [
+        f"Maximum length: {max_length} characters including spaces.",
+        "Write a single paragraph suitable for an X/Twitter post.",
+        "Adopt a first-person point of view and add a clear takeaway.",
+        "Avoid hashtags, emoji, and trailing questions.",
+        f"Tone: {tone}",
+    ]
+
+    prompt = textwrap.dedent(
+        f"""
+        Write a concise social media post summarizing and reacting to the article below for an X/Twitter audience.
+
+        Persona guidance:
+        {persona_text}
+
+        Guardrails:
+        {textwrap.indent('\n'.join(f'- {g}' for g in guardrails), ' ')}
+
+        Article metadata:
+        {textwrap.indent('\n'.join(lines), ' ')}
+
+        Return only the post text with no surrounding quotes.
+        """
+    ).strip()
+
+    return prompt
+
+
+def _first_non_empty(data: Dict[str, Any], keys: Iterable[str]) -> str:
+    for key in keys:
+        value = data.get(key)
+        if value:
+            value_str = str(value).strip()
+            if value_str:
+                return value_str
+    return ""
+
+
+__all__ = ["load_llm_settings", "summarize_rss_item"]

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,97 @@
+import pytest
+
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import llm_client
+
+
+def test_load_llm_settings_requires_api_key():
+    settings = {"rss_persona_text": "Voice", "rss_max_post_length": 200}
+    assert llm_client.load_llm_settings(settings) is None
+
+
+def test_load_llm_settings_parses_fields():
+    settings = {
+        "openai_api_key": "  key  ",
+        "rss_persona_text": "Confident operator voice",
+        "rss_max_post_length": "320",
+        "openai_model": "gpt-test",
+        "openai_base_url": "https://example.com/api",
+        "openai_temperature": "0.42",
+        "openai_timeout": "18",
+        "rss_persona_tone": "Calm and direct.",
+    }
+    cfg = llm_client.load_llm_settings(settings)
+    assert cfg is not None
+    assert cfg["api_key"] == "key"
+    assert cfg["persona_text"] == "Confident operator voice"
+    assert cfg["max_length"] == 320
+    assert cfg["model"] == "gpt-test"
+    assert cfg["base_url"] == "https://example.com/api"
+    assert cfg["tone"] == "Calm and direct."
+    assert cfg["temperature"] == pytest.approx(0.42)
+    assert cfg["timeout"] == pytest.approx(18.0)
+
+
+def test_summarize_rss_item_builds_prompt(monkeypatch):
+    captured = {}
+
+    class DummyResponse:
+        def __init__(self, payload):
+            self.payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"choices": [{"message": {"content": "Generated post"}}]}
+
+    def fake_post(url, headers, json, timeout):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["payload"] = json
+        captured["timeout"] = timeout
+        return DummyResponse(json)
+
+    class DummyRequests:
+        @staticmethod
+        def post(url, headers, json, timeout):
+            return fake_post(url, headers, json, timeout)
+
+    monkeypatch.setattr(llm_client, "requests", DummyRequests)
+
+    persona_settings = {
+        "api_key": "secret",
+        "persona_text": "Energetic builder voice that highlights the takeaway.",
+        "max_length": 190,
+        "model": "gpt-4o-mini",
+        "base_url": "https://example.com/v1",
+        "tone": "Direct yet friendly.",
+        "temperature": 0.2,
+        "timeout": 12,
+    }
+    rss_item = {
+        "title": "Launch announced",
+        "summary": "A startup released a new product",
+        "link": "https://news.example.com/item",
+        "source": "NewsWire",
+    }
+
+    text = llm_client.summarize_rss_item(rss_item, persona_settings)
+    assert text == "Generated post"
+
+    payload = captured["payload"]
+    assert payload["model"] == "gpt-4o-mini"
+    assert payload["messages"][1]["content"].count("Launch announced") == 1
+    assert "Energetic builder voice" in payload["messages"][1]["content"]
+    assert "190" in payload["messages"][1]["content"]
+    assert "Direct yet friendly." in payload["messages"][1]["content"]
+    assert "https://news.example.com/item" in payload["messages"][1]["content"]
+    assert captured["url"].endswith("/chat/completions")
+    assert captured["headers"]["Authorization"] == "Bearer secret"
+    assert captured["timeout"] == 12

--- a/tests/test_post_scheduler.py
+++ b/tests/test_post_scheduler.py
@@ -33,3 +33,70 @@ def test_post_scheduler_handles_cancel():
     ps._trigger_post()
     assert not pause.is_set()
 
+
+def test_generate_post_from_rss_with_llm(monkeypatch):
+    import post_scheduler
+    import llm_client
+
+    rss_item = {"title": "AI title"}
+    settings = {
+        "openai_api_key": "secret",
+        "rss_persona_text": "Builder voice",
+        "rss_max_post_length": 180,
+    }
+
+    captured = {}
+
+    def fake_load(config):
+        captured["settings"] = config
+        return {"persona_text": "Builder", "api_key": "secret", "max_length": 180}
+
+    def fake_summary(item, persona):
+        captured["rss_item"] = item
+        captured["persona"] = persona
+        return "LLM summary"
+
+    monkeypatch.setattr(post_scheduler, "_llm_client", llm_client)
+    monkeypatch.setattr(llm_client, "load_llm_settings", fake_load)
+    monkeypatch.setattr(llm_client, "summarize_rss_item", fake_summary)
+
+    text, media = post_scheduler.generate_post_from_rss(rss_item, settings)
+    assert text == "LLM summary"
+    assert media is None
+    assert captured["settings"] is settings
+    assert captured["rss_item"] is rss_item
+    assert captured["persona"]["api_key"] == "secret"
+
+
+def test_generate_post_from_rss_llm_failure(monkeypatch, caplog):
+    import post_scheduler
+    import llm_client
+
+    def fake_load(config):
+        return {"persona_text": "Persona", "api_key": "secret", "max_length": 200}
+
+    def fake_summary(item, persona):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(post_scheduler, "_llm_client", llm_client)
+    monkeypatch.setattr(llm_client, "load_llm_settings", fake_load)
+    monkeypatch.setattr(llm_client, "summarize_rss_item", fake_summary)
+
+    rss_item = {"title": "Original"}
+    with caplog.at_level("ERROR"):
+        text, media = post_scheduler.generate_post_from_rss(rss_item, {})
+
+    assert text == "Original"
+    assert media is None
+    assert any("LLM summarisation failed" in rec.message for rec in caplog.records)
+
+
+def test_generate_post_from_rss_without_credentials(monkeypatch):
+    import post_scheduler
+
+    monkeypatch.setattr(post_scheduler, "requests", None)
+    rss_item = {"title": "Fallback"}
+    text, media = post_scheduler.generate_post_from_rss(rss_item, {})
+    assert text == "Fallback"
+    assert media is None
+


### PR DESCRIPTION
## Summary
- add a reusable `llm_client` helper that prepares OpenAI settings, builds the summarisation prompt, and calls the chat completion API
- update `generate_post_from_rss` to delegate to the helper with error handling while keeping the existing placeholder fallback
- extend the settings UI/model to collect persona guidance, maximum length, and API credentials together with regression tests for the new behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca66fe07a883218feea0129f40717c