### PR TITLE
Cycle section queries sequentially

### DIFF
--- a/tests/test_send_reply.py
+++ b/tests/test_send_reply.py
@@ -50,6 +50,14 @@ def test_build_search_url_latest():
     assert url == "https://x.com/search?q=rocket%20science&src=typed_query&f=live"
 
 
+def test_section_pick_query_cycles_sequentially():
+    section = x.Section(name="Test", search_queries=["q1", "q2", "q3"])
+
+    picks = [section.pick_query() for _ in range(5)]
+
+    assert picks == ["q1", "q2", "q3", "q1", "q2"]
+
+
 def test_send_reply_linux(monkeypatch):
     dummy = DummyKB()
     worker = _make_worker(dummy)

--- a/x.py
+++ b/x.py
@@ -163,9 +163,16 @@ class Section:
     search_queries: List[str] = field(default_factory=list)
     responses: List[str] = field(default_factory=list)
     enabled: bool = True
+    _query_cycle_index: int = field(default=0, init=False, repr=False)
     def pick_typing_speed(self) -> int: return random.randint(*self.typing_ms_per_char)
     def pick_max_responses(self) -> int: return random.randint(*self.max_responses_before_switch)
-    def pick_query(self) -> Optional[str]: return random.choice(self.search_queries) if self.search_queries else None
+    def pick_query(self) -> Optional[str]:
+        if not self.search_queries:
+            return None
+        idx = self._query_cycle_index % len(self.search_queries)
+        query = self.search_queries[idx]
+        self._query_cycle_index = (idx + 1) % len(self.search_queries)
+        return query
     def pick_response(self) -> Optional[str]: return random.choice(self.responses) if self.responses else None
 
 # ---- Defaults (edit in UI later)


### PR DESCRIPTION
## Summary
- add state to Section so search queries cycle sequentially rather than randomly
- cover the new deterministic query order with a unit test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cba059dce08321810b0325c3435848