### PR TITLE
Fix section tab titles updating with renamed sections

### DIFF
--- a/x.py
+++ b/x.py
@@ -1236,8 +1236,17 @@ class App(tk.Tk):
                 row=0, column=2, sticky="w", padx=(12, 0)
             )
 
-            def update_tab_label(*_):
-                nb.tab(tab, text=self._section_tab_title(name_var.get(), fallback=default_name))
+            def update_tab_label(
+                *_,
+                notebook=nb,
+                current_tab=tab,
+                var=name_var,
+                default=default_name,
+            ):
+                notebook.tab(
+                    current_tab,
+                    text=self._section_tab_title(var.get(), fallback=default),
+                )
 
             update_tab_label()
             name_var.trace_add("write", update_tab_label)


### PR DESCRIPTION
## Summary
- capture the per-tab widgets when wiring the section name trace callback
- ensure section tab titles update when their names are edited

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbf1d3a1d48321b638e9a19e6fcfc6