### PR TITLE
Add per-section search mode configuration

### DIFF
--- a/tests/test_send_reply.py
+++ b/tests/test_send_reply.py
@@ -35,7 +35,6 @@ def _make_worker(kb):
     worker._push_to_clipboard = lambda text: None
     worker.stop_event = threading.Event()
     worker.pause_event = threading.Event()
-    worker.search_mode = "popular"
     worker._popular_initial_scroll_pending = False
     return worker
 


### PR DESCRIPTION
## Summary
- add per-section search filter controls and persist their defaults alongside section data
- drop the global search-mode preference in favour of storing a mode per section when saving profiles
- use the section-specific search modes when opening searches in the scheduler and refresh the accompanying tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d150bdfd4483218d9418e97526fc2b