### PR TITLE
Adjust popular search initial scroll depth

### DIFF
--- a/tests/test_send_reply.py
+++ b/tests/test_send_reply.py
@@ -19,7 +19,7 @@ STEP_PAUSE_MIN = x.STEP_PAUSE_MIN
 STEP_PAUSE_MAX = x.STEP_PAUSE_MAX
 FAST_J_INITIAL_DELAY_RANGE = x.FAST_J_INITIAL_DELAY_RANGE
 
-POPULAR_INITIAL_J_COUNT = x.POPULAR_INITIAL_J_COUNT
+POPULAR_INITIAL_J_RANGE = x.POPULAR_INITIAL_J_RANGE
 
 
 class DummyKB:
@@ -167,8 +167,12 @@ def test_press_j_batch_popular_initial_scroll(monkeypatch):
 
     ranges = []
 
+    initial_press_count = POPULAR_INITIAL_J_RANGE[0] + 1
+
     def fake_randint(a, b):
         ranges.append((a, b))
+        if (a, b) == POPULAR_INITIAL_J_RANGE:
+            return initial_press_count
 
         return 3
 
@@ -186,11 +190,11 @@ def test_press_j_batch_popular_initial_scroll(monkeypatch):
 
     assert worker._press_j_batch() is True
 
-    assert dummy.calls == [("press", "j")] * POPULAR_INITIAL_J_COUNT
-    assert ranges == []
+    assert dummy.calls == [("press", "j")] * initial_press_count
+    assert ranges == [POPULAR_INITIAL_J_RANGE]
 
     first_call_uniforms = uniform_calls.copy()
-    fast_count_first = min(2, POPULAR_INITIAL_J_COUNT)
+    fast_count_first = min(2, initial_press_count)
     assert first_call_uniforms[:fast_count_first] == [FAST_J_INITIAL_DELAY_RANGE] * fast_count_first
     assert all(r == (STEP_PAUSE_MIN, STEP_PAUSE_MAX) for r in first_call_uniforms[fast_count_first:])
 

--- a/x.py
+++ b/x.py
@@ -98,9 +98,10 @@ FAST_J_INITIAL_DELAY_RANGE = (0.0, 0.05)
 # ``Popular`` search results can surface stickied tweets, ads, or other
 # elements that require a deeper initial scroll before reaching fresh posts.
 # When the session opens a Popular search we overshoot the first batch of posts
-
-# by sending a fixed burst of nine ``j`` presses.
-POPULAR_INITIAL_J_COUNT = 9
+# by sending an initial burst of ``j`` presses.  Using a small random range of
+# presses avoids the mechanical feel of a fixed count while still ensuring we
+# scroll past the top-of-feed clutter.
+POPULAR_INITIAL_J_RANGE = (12, 15)
 
 
 POPULAR_SEARCH_MODES: Set[str] = {"popular", "top"}
@@ -804,7 +805,7 @@ class SchedulerWorker(threading.Thread):
     def _press_j_batch(self, stop_event: Optional[threading.Event] = None) -> bool:
         if getattr(self, "_popular_initial_scroll_pending", False):
 
-            presses = POPULAR_INITIAL_J_COUNT
+            presses = random.randint(*POPULAR_INITIAL_J_RANGE)
 
             self._popular_initial_scroll_pending = False
         else:


### PR DESCRIPTION
## Summary
- randomize the initial burst of `j` presses for popular searches to a 12–15 range
- update the send-reply tests to reflect the new initial scroll behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d28a68f3148321995706571d8a28f1