### PR TITLE
Increase page load wait thresholds

### DIFF
--- a/x.py
+++ b/x.py
@@ -84,8 +84,12 @@ def similarity_ratio(a: str, b: str) -> float:
     inter = len(ta & tb); union = len(ta | tb)
     return inter / max(1, union)
 
-BASE_WAIT = 3
-MAX_WAIT = 15
+# Wait slightly longer for pages to finish loading before we begin scanning
+# for content. Some users have reported that the bot occasionally started
+# scrolling before the feed fully populated, so we extend both the minimum and
+# maximum wait windows to give the page a better chance to settle.
+BASE_WAIT = 5
+MAX_WAIT = 25
 
 # Natural pauses inserted between high-level actions to mimic human pacing.
 STEP_PAUSE_MIN = 0.5


### PR DESCRIPTION
## Summary
- extend the minimum and maximum waits the bot allows after loading a page so feeds have longer to populate

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da6c5ef6208321ba758102c0281349