### PR TITLE
Fix Tk font initialization compatibility

### DIFF
--- a/x.py
+++ b/x.py
@@ -1283,7 +1283,10 @@ class App(tk.Tk):
             if tab_font_name
             else tkfont.nametofont("TkDefaultFont")
         )
-        self._section_tab_enabled_font = tkfont.Font(master=self, **base_tab_font.actual())
+        # ``tkfont.Font`` expects a ``root`` keyword argument for the parent widget.
+        # Using ``master`` raises ``TclError`` on newer Tk versions, so we pass
+        # the current widget via ``root`` instead.
+        self._section_tab_enabled_font = tkfont.Font(root=self, **base_tab_font.actual())
         self._section_tab_enabled_font.configure(weight="bold")
         self._section_enabled_bg = "#dbeafe"
         self._section_enabled_selected_bg = "#bfdbfe"


### PR DESCRIPTION
## Summary
- update the font initialization for section tabs to use the root keyword expected by tkinter
- prevent Tk runtime errors on newer Tcl/Tk versions when building the UI

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68db96ee4a288321af0338571726f64a