### PR TITLE
Add latest-without-replies search filter option

### DIFF
--- a/tests/test_send_reply.py
+++ b/tests/test_send_reply.py
@@ -78,6 +78,18 @@ def test_build_search_url_latest():
     assert url == "https://x.com/search?q=rocket%20science&src=typed_query&f=live"
 
 
+def test_build_search_url_latest_without_replies_adds_filter():
+    url = x.build_search_url("GM -filter:links", "Latest without replies")
+    assert url == (
+        "https://x.com/search?q=GM%20-filter%3Alinks%20-filter%3Areplies&src=typed_query&f=live"
+    )
+
+
+def test_build_search_url_latest_without_replies_respects_existing_filter():
+    url = x.build_search_url("GM -filter:replies", "latest_no_replies")
+    assert url == "https://x.com/search?q=GM%20-filter%3Areplies&src=typed_query&f=live"
+
+
 def test_section_pick_query_cycles_sequentially():
     section = x.Section(name="Test", search_queries=["q1", "q2", "q3"])
 


### PR DESCRIPTION
## Summary
- add a "Latest without replies" search mode that appends the replies filter when building X search URLs
- update the scheduler UI and configuration handling to surface the new mode alongside Popular and Latest
- extend send_reply tests to cover the new search mode behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4b839aa208321aaa990efef94210c